### PR TITLE
Revert "Fixing the read map function for the specific mod2svat.inp fo…

### DIFF
--- a/imod_coupler/metamod.py
+++ b/imod_coupler/metamod.py
@@ -26,12 +26,17 @@ def mapids(ids1, ids2):
 
 
 def read_mapping(map_file):
-    map_arr = np.loadtxt(map_file, dtype=str, delimiter=",")
+
+    map_arr = np.loadtxt(map_file, dtype=np.int32)
+    map_arr[:, 0] = (
+        map_arr[:, 0] - 1
+    )  # 1-based indices (fortran) to 0-based indices (python)
+    map_arr[:, 1] = map_arr[:, 1] - 1
+
     map_in = {}
-    for sgw, ssv in map_arr:
-        gw = int(sgw) - 1
-        sv = int(ssv.replace("'", "").split()[0])
-        map_in.setdefault(gw, []).append(sv - 1)
+    for gw, sv in zip(map_arr[:, 0], map_arr[:, 1]):
+        map_in.setdefault(gw, []).append(sv)
+
     return map_in
 
 
@@ -226,3 +231,4 @@ class MetaMod(AmiWrapper):
         # because the condition "if i in map_msw2mod" is never true.
         # Initalize the heads in MetaSWAP by copying them from MODFLOW
         self.xchg_mod2msw()
+


### PR DESCRIPTION
This reverts commit 0097d12c7c48ac5b7acd4f8901ba151f3a2f8122.

I discussed this with Robert, and the strip model example has a mod2svat.inp with a format that does not really conform to what is "normal" for MetaSWAP. All files I've seen, except the mod2svat.inp in the strip model, pad with spaces and do not use comma'
s and quotes as seperators. 

I think this specfic mod2svat.inp file in the strip model creeped in during the development of the coupler script, as it is easier to parse with regex, which was used initially to read input files in this python script. 

It is therefore probably better to fix the mod2svat.inp file in the strip model example instead and conform to what is usual than to force others to stick to our specific format.

tl;dr: It is best to revert this commit ;-)