### PR TITLE
Crucial fixes to the metamod.py script:

### DIFF
--- a/imod_coupler/metamod.py
+++ b/imod_coupler/metamod.py
@@ -136,7 +136,7 @@ class MetaMod:
         mf6_max_iter_tag = self.mf6.get_var_address("MXITER", "SLN_1")
 
         self.mf6_head = self.mf6.get_value_ptr(mf6_head_tag)
-        self.mf6_recharge = self.mf6.get_value_ptr(mf6_recharge_tag)[:,0] # recharge is the first column in the MODFLOW BOUND array
+        self.mf6_recharge = self.mf6.get_value_ptr(mf6_recharge_tag)[:, 0]  # set to first column in BOUND
         self.mf6_storage = self.mf6.get_value_ptr(mf6_storage_tag)
         self.mf6_sto_reset = self.mf6.get_value_ptr(mf6_sto_reset_tag)
         self.max_iter = self.mf6.get_value_ptr(mf6_max_iter_tag)[0]

--- a/imod_coupler/metamod.py
+++ b/imod_coupler/metamod.py
@@ -136,7 +136,8 @@ class MetaMod:
         mf6_max_iter_tag = self.mf6.get_var_address("MXITER", "SLN_1")
 
         self.mf6_head = self.mf6.get_value_ptr(mf6_head_tag)
-        self.mf6_recharge = self.mf6.get_value_ptr(mf6_recharge_tag)[:, 0]  # set to first column in BOUND
+        # NB: recharge is set to first column in BOUND
+        self.mf6_recharge = self.mf6.get_value_ptr(mf6_recharge_tag)[:, 0]
         self.mf6_storage = self.mf6.get_value_ptr(mf6_storage_tag)
         self.mf6_sto_reset = self.mf6.get_value_ptr(mf6_sto_reset_tag)
         self.max_iter = self.mf6.get_value_ptr(mf6_max_iter_tag)[0]


### PR DESCRIPTION
- SC1 should be used, not SC2
- there is a reset flag that should be set whenever the value changes to trigger
modflow side effects
- Recharge is the first column in the BOUND array, which has rank 2!
- there's no head exchange into metaswap inside the initialize, BUT,
there should be one before the iteration loop
- array assignment results causes the member (e.g. self.mf6_head) to no
longer point to the proper array inside the Fortran kernel, replaced this
by broadcast

This addresses issue IMOD6-271, which should be tested again.

(Paired with RL)