### PR TITLE
Finalize CLI interface

### DIFF
--- a/imod_coupler/__main__.py
+++ b/imod_coupler/__main__.py
@@ -16,9 +16,29 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
+        "config_path",
+        action="store",
+        help="specify the path to the configuration file",
+    )
+
+    parser.add_argument(
+        "--log-level",
+        action="store",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="define log level",
+    )
+
+    parser.add_argument(
+        "--timing",
+        action="store_true",
+        help="activate timing (verbosity can be adjusted with the log-level)",
+    )
+
+    parser.add_argument(
         "--enable-debug-native",
         action="store_true",
-        help="stop the script to wait for the native debugger.",
+        help="stop the script to wait for the native debugger",
     )
 
     parser.add_argument(
@@ -27,38 +47,31 @@ def main():
         version="%(prog)s {version}".format(version=__version__),
     )
 
-    parser.add_argument(
-        "--config-path",
-        action="store",
-        required=True,
-        help="specify the path to the configuration file.",
-    )
-
     args = parser.parse_args()
-    debug_native = args.enable_debug_native
     config_path = args.config_path
+    logging.basicConfig(level=args.log_level)
+    timing = args.timing
+    debug_native = args.enable_debug_native
+
+    if timing:
+        start = time.perf_counter()
 
     try:
-        config = Config(config_path)
+        config = Config(config_path, timing)
     except ConfigError as e:
         logger.error("Could not parse configuration file")
         logger.error(e)
         sys.exit(1)
 
-    logging.basicConfig(level=config.log_level)
-
-    timing = config.timing
-    if timing:
-        start = time.perf_counter()
-
-    # wait for native debugging
     if debug_native:
+        # wait for native debugging
         input(f"PID: {os.getpid()}, press any key to continue ....")
 
+    kernels = config.kernels
     for exchange in config.exchanges:
         if "modflow6" in exchange["kernels"] and "metaswap" in exchange["kernels"]:
-            mf6 = config.kernels["modflow6"]
-            msw = config.kernels["metaswap"]
+            mf6 = kernels["modflow6"]
+            msw = kernels["metaswap"]
 
             # Print output to stdout
             mf6.set_int("ISTDOUTTOFILE", 0)
@@ -69,17 +82,22 @@ def main():
 
             # Create an instance
             metamod = MetaMod(mf6=mf6, msw=msw, timing=timing)
+
             # Run the time loop
             start_time, current_time, end_time = metamod.getTimes()
-
             while current_time < end_time:
                 current_time = metamod.update_coupled()
             logger.info("New Simulation terminated normally")
 
-            if timing:
-                metamod.report_timing_totals()
-                end = time.perf_counter()
-                logger.info(f"Total elapsed time: {end-start:0.4f} seconds")
+    # Report timing
+    if timing:
+        total = 0
+        for kernel in kernels.values():
+            total += kernel.report_timing_totals()
+        logger.info(f"Total elapsed time in numerical kernels: {total:0.4f} seconds")
+
+        end = time.perf_counter()
+        logger.info(f"Total elapsed time: {end-start:0.4f} seconds")
 
 
 if __name__ == "__main__":

--- a/imod_coupler/config.py
+++ b/imod_coupler/config.py
@@ -14,7 +14,7 @@ logger = logging.getLogger()
 
 
 class Config(object):
-    def __init__(self, filepath):
+    def __init__(self, filepath, timing):
         """
         Args:
             filepath (str): Path to config file
@@ -28,14 +28,10 @@ class Config(object):
             self.filepath = filepath
 
             self.exchanges = self._get_cfg(["exchanges"])
-            self.timing = self._get_cfg(["timing"], default=False, required=False)
-            self.log_level = self._get_cfg(
-                ["log_level"], default="INFO", required=False
-            )
 
             kernels = self.get_kernel_set()
 
-            self.get_kernel_data(kernels)
+            self.get_kernel_data(kernels, timing)
 
     def get_kernel_set(self):
         """Get kernels and check if they match up"""
@@ -53,7 +49,7 @@ class Config(object):
 
         return expected_kernels
 
-    def get_kernel_data(self, kernels):
+    def get_kernel_data(self, kernels, timing):
         self.kernels = {}
         for kernel in kernels:
             # Validate paths
@@ -85,7 +81,7 @@ class Config(object):
                 lib_path=dll,
                 lib_dependency=dll_dependency,
                 working_directory=model,
-                timing=self.timing,
+                timing=timing,
             )
 
     def _get_cfg(self, path, default=None, required=True):

--- a/imod_coupler/metamod.py
+++ b/imod_coupler/metamod.py
@@ -94,17 +94,6 @@ class MetaMod:
             self.mf6.get_end_time(),
         )
 
-    def report_timing_totals(self):
-        """Report total time spent in numerical kernels to logger"""
-        if self.timing:
-            total = self.mf6.report_timing_totals() + self.msw.report_timing_totals()
-            logger.info(
-                f"Total elapsed time in numerical kernels: {total:0.4f} seconds"
-            )
-            return total
-        else:
-            raise Exception("Timing not activated")
-
     def couple(self):
         """Couple Modflow and Metaswap"""
         # get some 'pointers' to MF6 and MSW internal data


### PR DESCRIPTION
After a talk with Joeri, I try to to finalize the command line interface with this PR.
New options can be added, but existing ones should not be modified anymore.

This PR includes
- timing and log_level is moved to CLI again
- config_path is a positional parameter now
- refactor timing (otherwise it would stop working
   when we add additional kernels)

Instead of
```
imodc --config-path=/path/to/imod_coupler.toml
```
it is now
```
imodc /path/to/imod_coupler.toml
```

The necessary changes are already done in the testbench, so as soon as this is merged it should work again.

The current design is:
- user- (or developer-) specific settings via the CLI
- model settings via the config file (which can be overriden via env variables)

If you have any last design suggestions, please free to add them :)

JIRA issue can be found here https://issuetracker.deltares.nl/browse/IMOD6-362