### PR TITLE
Global environment variables in toml-section at Joeri's request

### DIFF
--- a/imod_coupler/config.py
+++ b/imod_coupler/config.py
@@ -33,6 +33,10 @@ class Config(object):
 
             self.get_kernel_data(kernels, timing)
 
+            envvars = self._get_cfg(["envvars"], default={}, required=False)
+            for varname, varcontent in envvars.items():
+                os.environ[varname] = varcontent
+
     def get_kernel_set(self):
         """Get kernels and check if they match up"""
 


### PR DESCRIPTION
Joeri requested the possibility to add global environment variables to the toml file. I added and tested it. Please discuss with Joeri and decided if that is still desired. To be honest, I was against it: users should open a dosbox to set the environment