### PR TITLE
Fix flow direction

### DIFF
--- a/imod_coupler/metamod.py
+++ b/imod_coupler/metamod.py
@@ -32,14 +32,10 @@ class MetaMod:
         """Exchange Metaswap to Modflow"""
         self.mf6_storage[:] = self.map_mod2msw["storage"].dot(self.msw_storage)[:]
         self.mf6_sto_reset[0] = 1
-        # Divide by delta time,
-        # since Metaswap only keeps track of volumes
-        # leaving its domain, not fluxes
-        # Multiply with -1 as recharge is leaving MetaSWAP (negative)
-        # and entering MF6 (positive)
+        # Divide by delta time
 
         self.mf6_recharge[:] = self.map_mod2msw["recharge"].dot(self.msw_volume)[:]
-        self.mf6_recharge[:] /= -1.0 * self.delt
+        self.mf6_recharge[:] /= self.delt
 
     def xchg_mod2msw(self):
         """Exchange Modflow to Metaswap"""

--- a/imod_coupler/metamod.py
+++ b/imod_coupler/metamod.py
@@ -32,8 +32,8 @@ class MetaMod:
         """Exchange Metaswap to Modflow"""
         self.mf6_storage[:] = self.map_mod2msw["storage"].dot(self.msw_storage)[:]
         self.mf6_sto_reset[0] = 1
+        
         # Divide by delta time
-
         self.mf6_recharge[:] = self.map_mod2msw["recharge"].dot(self.msw_volume)[:]
         self.mf6_recharge[:] /= self.delt
 

--- a/imod_coupler/metamod.py
+++ b/imod_coupler/metamod.py
@@ -32,7 +32,7 @@ class MetaMod:
         """Exchange Metaswap to Modflow"""
         self.mf6_storage[:] = self.map_mod2msw["storage"].dot(self.msw_storage)[:]
         self.mf6_sto_reset[0] = 1
-        
+
         # Divide by delta time
         self.mf6_recharge[:] = self.map_mod2msw["recharge"].dot(self.msw_volume)[:]
         self.mf6_recharge[:] /= self.delt


### PR DESCRIPTION
Changed the sign of the `qmodf` flow between MF6 and MetaSWAP. 

I implemented this incorrectly before, to account for errors that were apparently created by the diverging heads. 

The head divergence issue is now fixed in the MetaSWAP.dll and it seems that multiplying `qmodf` with -1.0 created an erronous coupling and should therefore be reverted.