### PR TITLE
Make iMOD Coupler compatible with Python 3.8

### DIFF
--- a/imod_coupler/drivers/metamod/metamod.py
+++ b/imod_coupler/drivers/metamod/metamod.py
@@ -3,6 +3,8 @@
 description:
 
 """
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Any
@@ -123,6 +125,7 @@ class MetaMod:
             raise ValueError(
                 f"'{dll}' for '{kernel_name}' is not a valid path to a file."
             )
+        dll = str(dll) # Force to string for ctypes
 
         work_dir_str = self.config["driver"]["kernels"][kernel_name]["work_dir"]
         work_dir = self.get_absolute_path(work_dir_str)
@@ -139,6 +142,7 @@ class MetaMod:
                 raise ValueError(
                     f"'{dll_dep_dir}' for '{kernel_name}' is not a valid path to a directory."
                 )
+            dll_dep_dir = str(dll_dep_dir) # Force to string for ctypes
         else:
             dll_dep_dir = None
 

--- a/imod_coupler/drivers/metamod/metamod.py
+++ b/imod_coupler/drivers/metamod/metamod.py
@@ -125,7 +125,7 @@ class MetaMod:
             raise ValueError(
                 f"'{dll}' for '{kernel_name}' is not a valid path to a file."
             )
-        dll = str(dll) # Force to string for ctypes
+        dll = str(dll)  # Force to string for ctypes
 
         work_dir_str = self.config["driver"]["kernels"][kernel_name]["work_dir"]
         work_dir = self.get_absolute_path(work_dir_str)
@@ -142,7 +142,7 @@ class MetaMod:
                 raise ValueError(
                     f"'{dll_dep_dir}' for '{kernel_name}' is not a valid path to a directory."
                 )
-            dll_dep_dir = str(dll_dep_dir) # Force to string for ctypes
+            dll_dep_dir = str(dll_dep_dir)  # Force to string for ctypes
         else:
             dll_dep_dir = None
 

--- a/imod_coupler/drivers/metamod/metamod.py
+++ b/imod_coupler/drivers/metamod/metamod.py
@@ -125,7 +125,6 @@ class MetaMod:
             raise ValueError(
                 f"'{dll}' for '{kernel_name}' is not a valid path to a file."
             )
-        dll = str(dll)  # Force to string for ctypes
 
         work_dir_str = self.config["driver"]["kernels"][kernel_name]["work_dir"]
         work_dir = self.get_absolute_path(work_dir_str)
@@ -142,7 +141,6 @@ class MetaMod:
                 raise ValueError(
                     f"'{dll_dep_dir}' for '{kernel_name}' is not a valid path to a directory."
                 )
-            dll_dep_dir = str(dll_dep_dir)  # Force to string for ctypes
         else:
             dll_dep_dir = None
 

--- a/imod_coupler/utils.py
+++ b/imod_coupler/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from contextlib import contextmanager
 from pathlib import Path
@@ -6,7 +8,6 @@ from typing import Any, Generator
 import numpy as np
 from numpy.typing import NDArray
 from scipy.sparse import csr_matrix
-
 
 def create_mapping(
     src_idx: Any, tgt_idx: Any, nsrc: int, ntgt: int, operator: str

--- a/imod_coupler/utils.py
+++ b/imod_coupler/utils.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.sparse import csr_matrix
 
+
 def create_mapping(
     src_idx: Any, tgt_idx: Any, nsrc: int, ntgt: int, operator: str
 ) -> tuple[csr_matrix, NDArray[np.int_]]:


### PR DESCRIPTION
There are some issues running iMOD Coupler on Python 3.8, these modifications make it work.
I'm not sure if the ``from __future__ import annotations`` breaks when useing Python 3.10.
