### PR TITLE
Import from typing module, to make the code compatible with python 3.8

### DIFF
--- a/tests/fixtures/fixture_model.py
+++ b/tests/fixtures/fixture_model.py
@@ -8,11 +8,12 @@ import xarray as xr
 from imod import mf6, msw
 from numpy import float_, int_, nan
 from numpy.typing import NDArray
+from typing import List, Tuple
 
 
-def grid_sizes() -> tuple[
-    list[float],
-    list[float],
+def grid_sizes() -> Tuple[
+    List[float],
+    List[float],
     NDArray[int_],
     pd.DatetimeIndex,
     float,

--- a/tests/fixtures/fixture_model.py
+++ b/tests/fixtures/fixture_model.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -8,7 +9,6 @@ import xarray as xr
 from imod import mf6, msw
 from numpy import float_, int_, nan
 from numpy.typing import NDArray
-from typing import List, Tuple
 
 
 def grid_sizes() -> Tuple[


### PR DESCRIPTION
Minor thing, but python 3.8 requires objects from the ``typing`` module for its type annotations.