### PR TITLE
Imod 985 mf6 validation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pip
   - pip:
       - xmipy
-      - git+https://gitlab.com/deltares/imod/imod-python.git@fd4d71293a434b9d8d3fbf65b12f2f235867fd7b
+      - git+https://gitlab.com/deltares/imod/imod-python.git@e6dca61fcfd5fc74d7021093d2d66d8e92364982
   - pydantic
   - pydata-sphinx-theme
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pip
   - pip:
       - xmipy
-      - git+https://gitlab.com/deltares/imod/imod-python.git@e6dca61fcfd5fc74d7021093d2d66d8e92364982
+      - imod>=0.11.6
   - pydantic
   - pydata-sphinx-theme
   - pytest

--- a/tests/fixtures/fixture_model.py
+++ b/tests/fixtures/fixture_model.py
@@ -3,7 +3,6 @@ from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
-import pytest
 import pytest_cases
 import xarray as xr
 from imod import mf6, msw
@@ -11,14 +10,16 @@ from numpy import float_, int_, nan
 from numpy.typing import NDArray
 
 
-def grid_sizes() -> Tuple[
-    List[float],
-    List[float],
-    NDArray[int_],
-    float,
-    float,
-    NDArray[float_],
-]:
+def grid_sizes() -> (
+    Tuple[
+        List[float],
+        List[float],
+        NDArray[int_],
+        float,
+        float,
+        NDArray[float_],
+    ]
+):
     x = [100.0, 200.0, 300.0, 400.0, 500.0]
     y = [300.0, 200.0, 100.0]
     dz = np.array([0.2, 10.0, 100.0])
@@ -362,7 +363,6 @@ def convert_storage_package(
     return gwf_model
 
 
-#%% Helper fixtures
 def make_idomain() -> xr.DataArray:
     x, y, layer, dx, dy, _ = grid_sizes()
 
@@ -395,7 +395,6 @@ def inactive_idomain() -> xr.DataArray:
     return idomain
 
 
-#%% Case fixtures
 @pytest_cases.fixture(scope="function")
 def coupled_mf6_model(active_idomain: xr.DataArray) -> mf6.Modflow6Simulation:
     return make_coupled_mf6_model(active_idomain)
@@ -428,7 +427,6 @@ def prepared_msw_model(
     active_idomain: xr.DataArray,
     metaswap_lookup_table: Path,
 ) -> msw.MetaSwapModel:
-
     msw_model = make_msw_model(active_idomain)
     # Override unsat_svat_path with path from environment
     msw_model.simulation_settings[
@@ -443,7 +441,6 @@ def prepared_msw_model_inactive(
     inactive_idomain: xr.DataArray,
     metaswap_lookup_table: Path,
 ) -> msw.MetaSwapModel:
-
     msw_model = make_msw_model(inactive_idomain)
     # Override unsat_svat_path with path from environment
     msw_model.simulation_settings[

--- a/tests/fixtures/fixture_model.py
+++ b/tests/fixtures/fixture_model.py
@@ -148,11 +148,14 @@ def make_msw_model(idomain: xr.DataArray) -> msw.MetaSwapModel:
     times = get_times()
     unsaturated_database = "./unsat_database"
 
-    x, y, _, dx, dy, _ = grid_sizes()
+    x, y, layer, dx, dy, dz = grid_sizes()
     subunit = [0, 1]
 
     nrow = len(y)
     ncol = len(x)
+
+    top = 0.0
+    bottom = top - xr.DataArray(np.cumsum(dz), coords={"layer": layer}, dims="layer")
 
     # fmt: off
     relative_area = xr.DataArray(
@@ -232,9 +235,9 @@ def make_msw_model(idomain: xr.DataArray) -> msw.MetaSwapModel:
     well = create_wells(nrow, ncol, idomain)
 
     # Modflow 6
-    idomain = xr.full_like(msw_grid, 1, dtype=int).expand_dims(layer=[1, 2, 3])
+    idomain = xr.full_like(msw_grid, 1, dtype=int).expand_dims(layer=layer)
 
-    dis = mf6.StructuredDiscretization(top=1.0, bottom=0.0, idomain=idomain)
+    dis = mf6.StructuredDiscretization(idomain=idomain, top=top, bottom=bottom)
 
     # Initiate model
     msw_model = msw.MetaSwapModel(unsaturated_database=unsaturated_database)

--- a/tests/test_config_cases.py
+++ b/tests/test_config_cases.py
@@ -7,7 +7,6 @@ def case_sprinkling(
     coupled_mf6_model: Modflow6Simulation,
     prepared_msw_model: MetaSwapModel,
 ) -> MetaMod:
-
     return MetaMod(
         prepared_msw_model,
         coupled_mf6_model,

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,5 +1,3 @@
-#%% Import
-
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
 from pytest_cases import parametrize_with_cases
@@ -7,7 +5,6 @@ from pytest_cases import parametrize_with_cases
 from imod_coupler.utils import create_mapping
 
 
-#%% Test
 @parametrize_with_cases(
     "src_idx,tgt_idx,nsrc,ntgt,operator,expected_map_dense,expected_mask"
 )

--- a/tests/test_metamod.py
+++ b/tests/test_metamod.py
@@ -108,6 +108,7 @@ def test_metamod_run_failure(
         modflow6_dll=modflow_dll_devel,
         metaswap_dll=metaswap_dll_devel,
         metaswap_dll_dependency=metaswap_dll_dep_dir_devel,
+        modflow6_write_kwargs={"validate": False},  # Turn off validation
     )
 
     with pytest.raises(subprocess.CalledProcessError):

--- a/tests/test_metamod_cases.py
+++ b/tests/test_metamod_cases.py
@@ -11,7 +11,6 @@ def case_sprinkling(
     coupled_mf6_model: Modflow6Simulation,
     prepared_msw_model: MetaSwapModel,
 ) -> MetaMod:
-
     return MetaMod(
         prepared_msw_model,
         coupled_mf6_model,
@@ -24,7 +23,6 @@ def case_no_sprinkling(
     coupled_mf6_model: Modflow6Simulation,
     prepared_msw_model: MetaSwapModel,
 ) -> MetaMod:
-
     prepared_msw_model.pop("sprinkling")
 
     return MetaMod(
@@ -39,7 +37,6 @@ def case_storage_coefficient(
     coupled_mf6_model_storage_coefficient: Modflow6Simulation,
     prepared_msw_model: MetaSwapModel,
 ) -> MetaMod:
-
     return MetaMod(
         prepared_msw_model,
         coupled_mf6_model_storage_coefficient,
@@ -52,7 +49,6 @@ def case_storage_coefficient_no_sprinkling(
     coupled_mf6_model_storage_coefficient: Modflow6Simulation,
     prepared_msw_model: MetaSwapModel,
 ) -> MetaMod:
-
     prepared_msw_model.pop("sprinkling")
 
     return MetaMod(
@@ -67,7 +63,6 @@ def case_inactive_cell(
     coupled_mf6_model_inactive: Modflow6Simulation,
     prepared_msw_model_inactive: MetaSwapModel,
 ) -> MetaMod:
-
     return MetaMod(
         prepared_msw_model_inactive,
         coupled_mf6_model_inactive,

--- a/tests/test_modstrip.py
+++ b/tests/test_modstrip.py
@@ -14,7 +14,6 @@ def write_toml(
     metaswap_dll_dep_dir_devel: Path,
     modflow_dll_devel: Path,
 ):
-
     coupling_dict = dict(
         mf6_model="GWF_1",
         mf6_msw_node_map="./NODENR2SVAT.DXC",


### PR DESCRIPTION
Fixes https://issuetracker.deltares.nl/browse/IMOD6-985, and should nullify the issue fixed in this PR https://github.com/Deltares/imod_coupler/pull/121

The latest iMOD Python release has added model input validation for Modflow 6. 

I took a shortcut in the ``msw_fixture``, for which I incorrectly provided the ``bottom`` in the MF6 discretization as a scalar.
This fixes this.

Furthermore, in one test, we want Modflow 6 to fail, not iMOD Python. So in this case I had to turn off the validation. To do this, I had to add a kwarg to a method in iMOD Python. So to have working tests, it is neatest to have a new iMOD Python release. 

For now, I updated the ``environment.yml``, so we can test.

If the iMOD Python pipeline runs succesfully, I can release a new iMOD Python version: https://gitlab.com/deltares/imod/imod-python/-/pipelines/761834486
