### PR TITLE
H5netcdf

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,9 +9,9 @@ dependencies:
   - black
   - build
   - geopandas
+  - h5netcdf
   - loguru
   - mypy
-  - netcdf4
   - numpy
   - pip
   - pip:

--- a/imod_coupler/logging/exchange_collector.py
+++ b/imod_coupler/logging/exchange_collector.py
@@ -2,7 +2,7 @@ import abc
 from pathlib import Path
 from typing import Any, Optional
 
-import netCDF4 as nc
+import h5netcdf.legacyapi as nc
 import numpy as np
 import tomli
 from numpy.typing import NDArray
@@ -33,7 +33,7 @@ class NetcdfExchangeLogger(AbstractExchange):
     def initfile(self, ndx: int) -> None:
         self.nodedim = self.ds.createDimension("id", ndx)
         self.timedim = self.ds.createDimension(
-            "time",
+            "time", None
         )
         self.timevar = self.ds.createVariable("time", "f8", ("time",))
         self.datavar = self.ds.createVariable(
@@ -53,7 +53,8 @@ class NetcdfExchangeLogger(AbstractExchange):
             self.initfile(len(exchange))
         loc = np.where(self.timevar[:] == time)
         if np.size(loc) > 0:
-            self.datavar[loc[0], :] = exchange[:]
+            first = int(loc[0])
+            self.datavar[first, :] = exchange[:]
         else:
             self.timevar[self.pos] = time
             self.datavar[self.pos, :] = exchange[:]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "netcdf4",
+    "h5netcdf",
     "numpy",
     "scipy",
     "xmipy",

--- a/tests/test_exchange_collector.py
+++ b/tests/test_exchange_collector.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-import netCDF4 as nc
+import h5netcdf.legacyapi as nc
 import numpy as np
 import pytest
 import tomli
@@ -70,12 +70,7 @@ def test_exchange_collector_raises_exception_when_array_size_varies(
 
     exchange_collector.log_exchange("example_stage_output", some_array, 8.0)
 
-    expected_error_message = (
-        "operands could not be broadcast together with remapped shapes "
-        + "[original->remapped]: (4,)  and requested shape (1,5)"
-    )
-
-    with pytest.raises(ValueError, match=re.escape(expected_error_message)):
+    with pytest.raises(TypeError, match=re.escape("Can't broadcast (4,) -> (1, 5)")):
         exchange_collector.log_exchange(
             "example_stage_output", some_smaller_array, 23.0
         )

--- a/tests/test_scripts/mf6_water_balance/combine.py
+++ b/tests/test_scripts/mf6_water_balance/combine.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Union
 
-import netCDF4 as nc
+import h5netcdf.legacyapi as nc
 import numpy as np
 import pandas as pd
 


### PR DESCRIPTION
Replace netCDF4 by the more minimal h5netcdf alternative.

There are, of course, some minor differences even with the legacy API.
Once we've merged the last imod-python merge request and released it on PyPI, we can omit geopandas and rasterio from the environment.yml.