### PR TITLE
Fix `tool.setuptools.packages.find`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ zip-safe = true
 [tool.setuptools.dynamic]
 version.attr = "imod_coupler.__version__"
 
+[tool.setuptools.packages.find]
+include = ["imod_coupler", "imod_coupler.*"]
+
 [tool.setuptools.package-data]
 "imod_coupler" = ["py.typed"]
 


### PR DESCRIPTION
The asterisk is necessary to find submodules