### PR TITLE
Enforce that Ribasim tests run on the same worker

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,7 @@ install = { depends_on = [
     "install-imodc",
 ] }
 # Tests
-tests = "pytest -n=auto --basetemp=tests/temp --junitxml=report.xml"
+tests = "pytest --numprocesses=auto --dist=loadgroup --basetemp=tests/temp --junitxml=report.xml"
 # Lint
 mypy-imodc = "mypy --ignore-missing-imports --strict imod_coupler"
 mypy-primod = "mypy --ignore-missing-imports pre-processing/primod"

--- a/tests/test_ribametamod.py
+++ b/tests/test_ribametamod.py
@@ -4,11 +4,13 @@ from pathlib import Path
 import imod
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.testing import assert_allclose
 from primod.ribametamod import RibaMetaMod
 from pytest_cases import parametrize_with_cases
 
 
+@pytest.mark.xdist_group(name="ribasim")
 @parametrize_with_cases("ribametamod_model")
 def test_ribametamod_develop(
     tmp_path_dev: Path,
@@ -34,6 +36,7 @@ def test_ribametamod_develop(
     )
 
 
+@pytest.mark.xdist_group(name="ribasim")
 @parametrize_with_cases("ribametamod_model", prefix="bucket_model")
 def test_ribamod_bucket(
     tmp_path_dev: Path,
@@ -71,6 +74,7 @@ def test_ribamod_bucket(
     assert final_storage < 60
 
 
+@pytest.mark.xdist_group(name="ribasim")
 @parametrize_with_cases("ribametamod_model", prefix="backwater")
 def test_ribametamod_backwater(
     tmp_path_dev: Path,
@@ -138,6 +142,7 @@ def test_ribametamod_backwater(
     assert (np.abs(budget_diff) < 0.02).all()
 
 
+@pytest.mark.xdist_group(name="ribasim")
 @parametrize_with_cases("ribametamod_model", prefix="two_basin")
 def test_ribamod_two_basin(
     tmp_path_dev: Path,

--- a/tests/test_ribamod.py
+++ b/tests/test_ribamod.py
@@ -4,11 +4,13 @@ from pathlib import Path
 import imod
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.testing import assert_allclose
 from primod.ribamod import RibaMod
 from pytest_cases import parametrize_with_cases
 
 
+@pytest.mark.xdist_group(name="ribasim")
 @parametrize_with_cases("ribamod_model")
 def test_ribamod_develop(
     tmp_path_dev: Path,
@@ -33,6 +35,7 @@ def test_ribamod_develop(
     )
 
 
+@pytest.mark.xdist_group(name="ribasim")
 @parametrize_with_cases("ribamod_model", prefix="bucket_model")
 def test_ribamod_bucket(
     tmp_path_dev: Path,
@@ -69,6 +72,7 @@ def test_ribamod_bucket(
     assert final_storage < 60
 
 
+@pytest.mark.xdist_group(name="ribasim")
 @parametrize_with_cases("ribamod_model", prefix="backwater")
 def test_ribamod_backwater(
     tmp_path_dev: Path,
@@ -135,6 +139,7 @@ def test_ribamod_backwater(
     assert (np.abs(budget_diff) < 0.02).all()
 
 
+@pytest.mark.xdist_group(name="ribasim")
 @parametrize_with_cases("ribamod_model", prefix="two_basin")
 def test_ribamod_two_basin(
     tmp_path_dev: Path,


### PR DESCRIPTION
Otherwise I've got the following error on TeamCity:

```
InitError(mod=:WindowsTimeZoneIDs, error=Base.IOError(msg="unlink("D:\\buildAgent\\work\\c463fd4bc9a9a18\\imod_collector_devel\\ribasim\\share\\julia\\scratchspaces\\f269a46b-ccf7-5d73-abea-4c690281aa53\\build\\local\\windowsZones.xml"): resource busy or locked (EBUSY)", code=-4082)
```