### PR TITLE
Move basin_definition from RibaMod to DriverCoupling

### DIFF
--- a/tests/fixtures/fixture_modflow.py
+++ b/tests/fixtures/fixture_modflow.py
@@ -411,36 +411,3 @@ def mf6_partial_two_basin_model() -> mf6.Modflow6Simulation:
         save_flows=True,
     )
     return two_basin_variation(idomain, river)
-
-
-@pytest_cases.fixture(scope="function")
-def mf6_uncoupled_two_basin_model() -> mf6.Modflow6Simulation:
-    """
-    This model has no spatial overlap with the Ribasim model.
-    It's simply shifted 1000 units to the left.
-
-    primod + imod_coupler should still be able to pre-process and run the
-    models.
-    """
-    x = np.arange(-1000.0, 0.0, 20.0)
-    y = np.arange(200.0, -220.0, -20.0)
-    layer = np.array([1])
-    shape = (layer.size, y.size, x.size)
-    dims = ["layer", "y", "x"]
-    coords = {"layer": layer, "y": y, "x": x}
-    idomain = xr.DataArray(data=np.ones(shape, dtype=int), coords=coords, dims=dims)
-
-    stage = xr.full_like(idomain, np.nan, dtype=float)
-    conductance = xr.full_like(idomain, np.nan, dtype=float)
-    bottom_elevation = xr.full_like(idomain, np.nan, dtype=float)
-    stage[:, 10, :] = 0.5
-    # Compute conductance as wetted area (length 20.0, width 1.0, entry resistance 1.0)
-    conductance[:, 10, :] = (20.0 * 1.0) / 1.0
-    bottom_elevation[:, 10, :] = 0.0
-    river = mf6.River(
-        stage=stage,
-        conductance=conductance,
-        bottom_elevation=bottom_elevation,
-        save_flows=True,
-    )
-    return two_basin_variation(idomain, river)

--- a/tests/test_primod/test_preprocessing_ribamod.py
+++ b/tests/test_primod/test_preprocessing_ribamod.py
@@ -74,6 +74,7 @@ def test_ribamod_write__error(
 
     driver_coupling = DriverCoupling(
         mf6_model=mf6_modelname,
+        basin_definition=basin_definition,
         mf6_active_river_packages=mf6_river_packages,
     )
 
@@ -86,7 +87,6 @@ def test_ribamod_write__error(
         ribasim_bucket_model,
         mf6_bucket_model,
         coupling_list=[driver_coupling],
-        basin_definition=basin_definition,
     )
     output_dir = tmp_path / "ribamod"
 
@@ -105,6 +105,7 @@ def test_ribamod_write(
 
     driver_coupling = DriverCoupling(
         mf6_model=mf6_modelname,
+        basin_definition=basin_definition,
         mf6_passive_river_packages=mf6_river_packages,
     )
 
@@ -112,7 +113,6 @@ def test_ribamod_write(
         ribasim_bucket_model,
         mf6_bucket_model,
         coupling_list=[driver_coupling],
-        basin_definition=basin_definition,
     )
     output_dir = tmp_path / "ribamod"
     coupling_dict, coupled_basin_node_ids = coupled_models.write_exchanges(output_dir)
@@ -142,6 +142,7 @@ def test_ribamod_write_toml(
 
     driver_coupling = DriverCoupling(
         mf6_model=mf6_modelname,
+        basin_definition=basin_definition,
         mf6_passive_river_packages=mf6_river_packages,
     )
 
@@ -149,7 +150,6 @@ def test_ribamod_write_toml(
         ribasim_bucket_model,
         mf6_bucket_model,
         coupling_list=[driver_coupling],
-        basin_definition=basin_definition,
     )
 
     output_dir = tmp_path / "ribamod"
@@ -194,6 +194,7 @@ def test_nullify_ribasim_exchange_input(
 
     driver_coupling = DriverCoupling(
         mf6_model=mf6_modelname,
+        basin_definition=basin_definition,
         mf6_passive_river_packages=mf6_river_packages,
     )
 
@@ -201,7 +202,6 @@ def test_nullify_ribasim_exchange_input(
         ribasim_bucket_model,
         mf6_bucket_model,
         coupling_list=[driver_coupling],
-        basin_definition=basin_definition,
     )
 
     # Should be not-NA before method call.
@@ -224,21 +224,21 @@ def test_nullify_on_write(
     mf6_modelname, mf6_model = get_mf6_gwf_modelnames(mf6_partial_two_basin_model)[0]
     mf6_river_packages = get_mf6_river_packagenames(mf6_model)
 
-    driver_coupling = DriverCoupling(
-        mf6_model=mf6_modelname,
-        mf6_passive_river_packages=mf6_river_packages,
-    )
-
     # This basin definition is still a point geometry.
     # This mean it will be rasterized to just two pixels.
     gdf = ribasim_two_basin_model.network.node.df
     gdf = gdf.loc[gdf["type"] == "Basin"].copy()
     gdf["node_id"] = gdf.index
+    driver_coupling = DriverCoupling(
+        mf6_model=mf6_modelname,
+        basin_definition=gdf,
+        mf6_passive_river_packages=mf6_river_packages,
+    )
+
     coupled_models = RibaMod(
         ribasim_two_basin_model,
         mf6_partial_two_basin_model,
         coupling_list=[driver_coupling],
-        basin_definition=gdf,
     )
     _, coupled_basin_node_ids = coupled_models.write_exchanges(tmp_path)
     assert np.array_equal(coupled_basin_node_ids, [2])

--- a/tests/test_ribametamod_cases.py
+++ b/tests/test_ribametamod_cases.py
@@ -36,13 +36,13 @@ def case_bucket_model(
 
     driver_coupling = DriverCoupling(
         mf6_model=mf6_modelname,
+        basin_definition=basin_definition,
         mf6_active_river_packages=mf6_active_river_packages,
     )
     # TODO: should becomde RibaMetaMod-class, including the MetaSWAP model
     return RibaMod(
         ribasim_model=ribasim_bucket_model,
         mf6_simulation=mf6_bucket_model,
-        basin_definition=basin_definition,
         coupling_list=[driver_coupling],
     ), msw_bucket_model
 

--- a/tests/test_ribamod.py
+++ b/tests/test_ribamod.py
@@ -243,28 +243,3 @@ def test_ribamod_partial_two_basin(
         (results.flow_df["from_node_id"] == 4) & (results.flow_df["to_node_id"] == 5)
     ]["flow"]
     assert flow_to_terminal.iloc[-1] < 1.0e-6
-
-
-@pytest.mark.xdist_group(name="ribasim")
-@parametrize_with_cases("ribamod_model", glob="uncoupled_two_basin_model")
-def test_ribamod_uncoupled_two_basin(
-    tmp_path_dev: Path,
-    ribamod_model: RibaMod,
-    modflow_dll_devel: Path,
-    ribasim_dll_devel: Path,
-    ribasim_dll_dep_dir_devel: Path,
-    run_coupler_function: Callable[[Path], None],
-) -> None:
-    """
-    Test if the partial two basin model works as expected if there's no spatial
-    overlap between the RibaMod and Modflow6 model.
-    """
-    # Should run without exceptions.
-    write_run_read(
-        tmp_path=tmp_path_dev,
-        ribamod_model=ribamod_model,
-        modflow_dll=modflow_dll_devel,
-        ribasim_dll=ribasim_dll_devel,
-        ribasim_dll_dep_dir=ribasim_dll_dep_dir_devel,
-        run_coupler_function=run_coupler_function,
-    )

--- a/tests/test_ribamod_cases.py
+++ b/tests/test_ribamod_cases.py
@@ -30,13 +30,13 @@ def case_bucket_model(
 
     driver_coupling = DriverCoupling(
         mf6_model=mf6_modelname,
+        basin_definition=basin_definition,
         mf6_active_river_packages=mf6_active_river_packages,
     )
 
     return RibaMod(
         ribasim_model=ribasim_bucket_model,
         mf6_simulation=mf6_bucket_model,
-        basin_definition=basin_definition,
         coupling_list=[driver_coupling],
     )
 
@@ -53,6 +53,7 @@ def case_backwater_model(
 
     driver_coupling = DriverCoupling(
         mf6_model=mf6_modelname,
+        basin_definition=basin_definition,
         mf6_active_river_packages=mf6_active_river_packages,
         mf6_active_drainage_packages=mf6_active_drainage_packages,
     )
@@ -60,7 +61,6 @@ def case_backwater_model(
     return RibaMod(
         ribasim_model=ribasim_backwater_model,
         mf6_simulation=mf6_backwater_model,
-        basin_definition=basin_definition,
         coupling_list=[driver_coupling],
     )
 
@@ -79,13 +79,13 @@ def two_basin_variation(
 
     driver_coupling = DriverCoupling(
         mf6_model=mf6_modelname,
+        basin_definition=basin_definition,
         mf6_active_river_packages=mf6_active_river_packages,
     )
 
     return RibaMod(
         ribasim_model=ribasim_two_basin_model,
         mf6_simulation=mf6_two_basin_model,
-        basin_definition=basin_definition,
         coupling_list=[driver_coupling],
     )
 
@@ -102,13 +102,6 @@ def case_partial_two_basin_model(
     ribasim_two_basin_model: ribasim.Model,
 ) -> RibaMod:
     return two_basin_variation(mf6_partial_two_basin_model, ribasim_two_basin_model)
-
-
-def case_uncoupled_two_basin_model(
-    mf6_uncoupled_two_basin_model: Modflow6Simulation,
-    ribasim_two_basin_model: ribasim.Model,
-) -> RibaMod:
-    return two_basin_variation(mf6_uncoupled_two_basin_model, ribasim_two_basin_model)
 
 
 def get_mf6_gwf_modelnames(


### PR DESCRIPTION
This moves the basin_definition entry to the DriverCoupling. The idea here is to support multiple "stacked" basins: they share geometries, but not the basin node_ids.

This allows us to do the following:

```python
driver_coupling_1 = DriverCoupling(
    mf6_model="GWF_1",
    mf6_active_river_packages=["riv-1"],
    mf6_active_drainage_packages=["riv-1_drainage"],
    basin_definition=basin_definition_1,
)
driver_coupling_2 = DriverCoupling(
    mf6_model="GWF_1",
    mf6_active_river_packages=["riv-2"],
    mf6_active_drainage_packages=["riv-2_drainage"],
    basin_definition=basin_definition_2,
)

ribamod_model = RibaMod(
    ribasim_model=ribasim_model,
    mf6_simulation=mf6_simulation,
    coupling_list=[driver_coupling_1, driver_coupling_2],
)
```

This PR doesn't actually tests or something for this use of multiple definitions. The goal is to avoid API changes in the future, because we'd like this version to be used already with just a single basin_definition.
In principle, however, the code here should already work for multiple basin_definitions, connected to different MODFLOW 6 packages. In the future, we should probably think about some checks and add them. For example: the basin_definitions should not have overlapping node_id's between them.

This now also raises an error if there is no overlap found between Ribasim basins and MF6 boundaries. This allows us to get rid of several if-else's.