### PR TITLE
Issue #262 primod rchsvatmapping layer dim

### DIFF
--- a/pre-processing/primod/mapping/rch_svat_mapping.py
+++ b/pre-processing/primod/mapping/rch_svat_mapping.py
@@ -39,12 +39,13 @@ class RechargeSvatMapping(MetaModMapping):
         super().__init__()
         self.dataset["svat"] = svat
         self.dataset["layer"] = xr.full_like(svat, 1)
-        if "layer" in recharge.dataset.coords:
-            self.dataset["rch_active"] = (
-                recharge.dataset["rate"].drop_vars("layer").notnull()
-            )
+        rate = recharge.dataset["rate"]
+        if "layer" in rate.dims:
+            rate_no_layer = rate.squeeze("layer", drop=True)
         else:
-            self.dataset["rch_active"] = recharge.dataset["rate"].notnull()
+            # 'layer' can be still in a coord, so ensure is also dropped
+            rate_no_layer = rate.drop_vars("layer", errors="ignore")
+        self.dataset["rch_active"] = rate_no_layer.notnull()
         self._pkgcheck()
         self._create_rch_id()
 

--- a/tests/fixtures/fixture_modflow.py
+++ b/tests/fixtures/fixture_modflow.py
@@ -149,13 +149,16 @@ def inactive_idomain() -> xr.DataArray:
 
     return idomain
 
+
 @pytest_cases.fixture(scope="function")
 def recharge(active_idomain: xr.DataArray) -> mf6.Recharge:
     return make_recharge(active_idomain)
 
+
 @pytest_cases.fixture(scope="function")
 def coupled_mf6_model(active_idomain: xr.DataArray) -> mf6.Modflow6Simulation:
     return make_coupled_mf6_model(active_idomain)
+
 
 @pytest_cases.fixture(scope="function")
 def mf6_bucket_model(active_idomain: xr.DataArray) -> mf6.Modflow6Simulation:

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,13 +1,16 @@
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
+import pytest
 from pytest_cases import parametrize_with_cases
 
 from imod_coupler.utils import create_mapping
+from imod import mf6
+from imod import msw
 
+from primod.mapping.rch_svat_mapping import RechargeSvatMapping
 
 @parametrize_with_cases(
-    "src_idx,tgt_idx,nsrc,ntgt,operator,expected_map_dense,expected_mask"
-)
+    "src_idx,tgt_idx,nsrc,ntgt,operator,expected_map_dense,expected_mask", prefix="util_")
 def test_create_mapping(
     src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 ):
@@ -27,3 +30,31 @@ def test_create_mapping(
 
     assert_almost_equal(map_out.toarray(), expected_map_dense)
     assert_array_equal(mask, expected_mask)
+
+
+@parametrize_with_cases(
+    "recharge", prefix="rch", has_tag="succeed")
+def test_recharge_mapping(
+    recharge: mf6.Recharge, prepared_msw_model: msw.MetaSwapModel
+):
+    """
+    Test Recharge package validation
+    """
+    _, svat = prepared_msw_model["grid"].generate_index_array()
+
+    rch_svat_mapping = RechargeSvatMapping(svat, recharge)
+    
+    assert np.all(rch_svat_mapping.dataset["layer"] == 1)
+    assert np.all(rch_svat_mapping.dataset["svat"] == svat)
+    assert rch_svat_mapping.dataset["rch_id"].max() == 12
+    assert rch_svat_mapping.dataset["rch_active"].sum() == 12
+
+@parametrize_with_cases(
+    "recharge", prefix="rch", has_tag="fail")
+def test_recharge_mapping_fail(
+    recharge: mf6.Recharge, prepared_msw_model: msw.MetaSwapModel
+):
+    _, svat = prepared_msw_model["grid"].generate_index_array()
+
+    with pytest.raises(ValueError):
+        RechargeSvatMapping(svat, recharge)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -9,8 +9,11 @@ from imod import msw
 
 from primod.mapping.rch_svat_mapping import RechargeSvatMapping
 
+
 @parametrize_with_cases(
-    "src_idx,tgt_idx,nsrc,ntgt,operator,expected_map_dense,expected_mask", prefix="util_")
+    "src_idx,tgt_idx,nsrc,ntgt,operator,expected_map_dense,expected_mask",
+    prefix="util_",
+)
 def test_create_mapping(
     src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 ):
@@ -32,8 +35,7 @@ def test_create_mapping(
     assert_array_equal(mask, expected_mask)
 
 
-@parametrize_with_cases(
-    "recharge", prefix="rch", has_tag="succeed")
+@parametrize_with_cases("recharge", prefix="rch", has_tag="succeed")
 def test_recharge_mapping(
     recharge: mf6.Recharge, prepared_msw_model: msw.MetaSwapModel
 ):
@@ -43,14 +45,14 @@ def test_recharge_mapping(
     _, svat = prepared_msw_model["grid"].generate_index_array()
 
     rch_svat_mapping = RechargeSvatMapping(svat, recharge)
-    
+
     assert np.all(rch_svat_mapping.dataset["layer"] == 1)
     assert np.all(rch_svat_mapping.dataset["svat"] == svat)
     assert rch_svat_mapping.dataset["rch_id"].max() == 12
     assert rch_svat_mapping.dataset["rch_active"].sum() == 12
 
-@parametrize_with_cases(
-    "recharge", prefix="rch", has_tag="fail")
+
+@parametrize_with_cases("recharge", prefix="rch", has_tag="fail")
 def test_recharge_mapping_fail(
     recharge: mf6.Recharge, prepared_msw_model: msw.MetaSwapModel
 ):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,13 +1,11 @@
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
+from imod import mf6, msw
+from numpy.testing import assert_almost_equal, assert_array_equal
+from primod.mapping.rch_svat_mapping import RechargeSvatMapping
 from pytest_cases import parametrize_with_cases
 
 from imod_coupler.utils import create_mapping
-from imod import mf6
-from imod import msw
-
-from primod.mapping.rch_svat_mapping import RechargeSvatMapping
 
 
 @parametrize_with_cases(

--- a/tests/test_mapping_cases.py
+++ b/tests/test_mapping_cases.py
@@ -2,6 +2,7 @@ import numpy as np
 import xarray as xr
 from pytest_cases import case
 
+
 def util_1_1_symmetric_sum():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([0, 1, 2], dtype=int)
@@ -165,14 +166,16 @@ def util_n_1_asymmetric_avg():
     )
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 
-@case(tags='succeed')
+
+@case(tags="succeed")
 def rch_2D(recharge):
     """
     Case where recharge is a 2D grid (y,x) and has a "layer" coord.
     """
     return recharge
 
-@case(tags='succeed')
+
+@case(tags="succeed")
 def rch_3D_layer_size_1(recharge):
     """
     Case where recharge has a third dimension "layer" with size one.
@@ -181,7 +184,8 @@ def rch_3D_layer_size_1(recharge):
     recharge.dataset = ds
     return recharge
 
-@case(tags='fail')
+
+@case(tags="fail")
 def rch_3D(recharge):
     """
     Case where recharge assigned to multiple layers.
@@ -192,7 +196,8 @@ def rch_3D(recharge):
     recharge.dataset = ds
     return recharge
 
-@case(tags='fail')
+
+@case(tags="fail")
 def rch_transient(recharge):
     """
     Case where rate has time dimension, should fail because mapping cannot

--- a/tests/test_mapping_cases.py
+++ b/tests/test_mapping_cases.py
@@ -1,7 +1,8 @@
 import numpy as np
+import xarray as xr
+from pytest_cases import case
 
-
-def case_1_1_symmetric_sum():
+def util_1_1_symmetric_sum():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([0, 1, 2], dtype=int)
 
@@ -20,7 +21,7 @@ def case_1_1_symmetric_sum():
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 
 
-def case_1_1_symmetric_avg():
+def util_1_1_symmetric_avg():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([0, 1, 2], dtype=int)
 
@@ -39,7 +40,7 @@ def case_1_1_symmetric_avg():
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 
 
-def case_1_1_asymmetric_sum():
+def util_1_1_asymmetric_sum():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([2, 3, 4], dtype=int)
 
@@ -61,7 +62,7 @@ def case_1_1_asymmetric_sum():
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 
 
-def case_1_1_asymmetric_avg():
+def util_1_1_asymmetric_avg():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([2, 3, 4], dtype=int)
 
@@ -83,7 +84,7 @@ def case_1_1_asymmetric_avg():
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 
 
-def case_n_1_symmetric_sum():
+def util_n_1_symmetric_sum():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([0, 1, 1], dtype=int)
 
@@ -102,7 +103,7 @@ def case_n_1_symmetric_sum():
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 
 
-def case_n_1_symmetric_avg():
+def util_n_1_symmetric_avg():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([0, 1, 1], dtype=int)
 
@@ -121,7 +122,7 @@ def case_n_1_symmetric_avg():
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 
 
-def case_n_1_asymmetric_sum():
+def util_n_1_asymmetric_sum():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([2, 2, 4], dtype=int)
 
@@ -143,7 +144,7 @@ def case_n_1_asymmetric_sum():
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
 
 
-def case_n_1_asymmetric_avg():
+def util_n_1_asymmetric_avg():
     src_idx = np.array([0, 1, 2], dtype=int)
     tgt_idx = np.array([2, 2, 4], dtype=int)
 
@@ -163,3 +164,44 @@ def case_n_1_asymmetric_avg():
         ]
     )
     return src_idx, tgt_idx, nsrc, ntgt, operator, expected_map_dense, expected_mask
+
+@case(tags='succeed')
+def rch_2D(recharge):
+    """
+    Case where recharge is a 2D grid (y,x) and has a "layer" coord.
+    """
+    return recharge
+
+@case(tags='succeed')
+def rch_3D_layer_size_1(recharge):
+    """
+    Case where recharge has a third dimension "layer" with size one.
+    """
+    ds = recharge.dataset.expand_dims("layer").assign_coords(layer=[1])
+    recharge.dataset = ds
+    return recharge
+
+@case(tags='fail')
+def rch_3D(recharge):
+    """
+    Case where recharge assigned to multiple layers.
+    """
+    ds = recharge.dataset.drop_vars("layer")
+    layer_data = xr.DataArray([1, 1, 1], coords={"layer": [1, 2, 3]}, dims=("layer",))
+    ds["rate"] = layer_data * ds["rate"]
+    recharge.dataset = ds
+    return recharge
+
+@case(tags='fail')
+def rch_transient(recharge):
+    """
+    Case where rate has time dimension, should fail because mapping cannot
+    change through time.
+    """
+    ds = recharge.dataset
+    times_str = ["2000-01-01", "2000-01-02", "2000-01-03"]
+    times = [np.datetime64(t) for t in times_str]
+    time_data = xr.DataArray([1, 1, 1], coords={"time": times}, dims=("time",))
+    ds["rate"] = time_data * ds["rate"]
+    recharge.dataset = ds
+    return recharge


### PR DESCRIPTION
This PR fixes issue #262, as well as adds some unit tests to verify that most common cases in which recharge can be provided work.

- 2D grid (y, x) with ``layer`` coord (succeeds)
- 3D grid with layer dimension, length 1 (succeeds)
- 3D grid with multiple layers (fails)
- 2D transient grid (fails)

I placed the new tests in the ``tests/test_mapping.py``, but I noticed there is a ``imod_coupler/mapping`` namespace, as well as a ``primod/mapping`` namespace. I was a bit in doubt whether mixing these in ``tests/test_mapping.py`` is a good idea. If you have ideas for a better location to put these tests, let me know.