### PR TITLE
Simplify enable_sprinkling

### DIFF
--- a/imod_coupler/drivers/metamod/config.py
+++ b/imod_coupler/drivers/metamod/config.py
@@ -35,9 +35,9 @@ class Coupling(BaseModel):
     def validate_mf6_msw_sprinkling_map(
         cls, mf6_msw_sprinkling_map_groundwater: FilePath | None, info: ValidationInfo
     ) -> FilePath | None:
-        assert info.config is not None
+        assert info.data is not None
         if mf6_msw_sprinkling_map_groundwater is not None:
-            if info.config.get("mf6_msw_well_pkg") is None:
+            if info.data.get("mf6_msw_well_pkg") is None:
                 raise ValueError(
                     "If 'mf6_msw_sprinkling_map_groundwater is set, then `mf6_msw_well_pkg` needs to be set."
                 )

--- a/imod_coupler/drivers/metamod/config.py
+++ b/imod_coupler/drivers/metamod/config.py
@@ -13,7 +13,6 @@ class Kernels(BaseModel):
 
 
 class Coupling(BaseModel):
-    enable_sprinkling: bool  # true whemn sprinkling is active
     mf6_model: str  # the MODFLOW 6 model that will be coupled
     mf6_msw_recharge_pkg: str  # the recharge package that will be used for coupling
     mf6_msw_well_pkg: str | None = (
@@ -21,41 +20,29 @@ class Coupling(BaseModel):
     )
     mf6_msw_node_map: FilePath  # the path to the node map file
     mf6_msw_recharge_map: FilePath  # the path to the recharge map file
-    mf6_msw_sprinkling_map: FilePath | None = (
+    mf6_msw_sprinkling_map_groundwater: FilePath | None = (
         None  # the path to the sprinkling map file
     )
     output_config_file: FilePath | None = None
-
-    @field_validator("mf6_msw_well_pkg")
-    @classmethod
-    def validate_mf6_msw_well_pkg(
-        cls, mf6_msw_well_pkg: str | None, info: ValidationInfo
-    ) -> str | None:
-        assert info.config is not None
-        if info.config.get("enable_sprinkling") and mf6_msw_well_pkg is None:
-            raise ValueError(
-                "If `enable_sprinkling` is True, then `mf6_msw_well_pkg` needs to be set."
-            )
-        return mf6_msw_well_pkg
 
     @field_validator("mf6_msw_node_map", "mf6_msw_recharge_map", "output_config_file")
     @classmethod
     def resolve_file_path(cls, file_path: FilePath) -> FilePath:
         return file_path.resolve()
 
-    @field_validator("mf6_msw_sprinkling_map")
+    @field_validator("mf6_msw_sprinkling_map_groundwater")
     @classmethod
     def validate_mf6_msw_sprinkling_map(
-        cls, mf6_msw_sprinkling_map: FilePath | None, info: ValidationInfo
+        cls, mf6_msw_sprinkling_map_groundwater: FilePath | None, info: ValidationInfo
     ) -> FilePath | None:
         assert info.config is not None
-        if mf6_msw_sprinkling_map is not None:
-            return mf6_msw_sprinkling_map.resolve()
-        elif info.config.get("enable_sprinkling"):
-            raise ValueError(
-                "If `enable_sprinkling` is True, then `mf6_msw_sprinkling_map` needs to be set."
-            )
-        return mf6_msw_sprinkling_map
+        if mf6_msw_sprinkling_map_groundwater is not None:
+            if info.config.get("mf6_msw_well_pkg") is None:
+                raise ValueError(
+                    "If 'mf6_msw_sprinkling_map_groundwater is set, then `mf6_msw_well_pkg` needs to be set."
+                )
+            return mf6_msw_sprinkling_map_groundwater.resolve()
+        return mf6_msw_sprinkling_map_groundwater
 
 
 class MetaModConfig(BaseModel):

--- a/imod_coupler/drivers/ribametamod/config.py
+++ b/imod_coupler/drivers/ribametamod/config.py
@@ -58,9 +58,9 @@ class Coupling(BaseModel):
     def validate_mf6_msw_sprinkling_map(
         cls, mf6_msw_sprinkling_map_groundwater: FilePath | None, info: ValidationInfo
     ) -> FilePath | None:
-        assert info.config is not None
+        assert info.data is not None
         if mf6_msw_sprinkling_map_groundwater is not None:
-            if info.config.get("mf6_msw_well_pkg") is None:
+            if info.data.get("mf6_msw_well_pkg") is None:
                 raise ValueError(
                     "If 'mf6_msw_sprinkling_map_groundwater is set, then `mf6_msw_well_pkg` needs to be set."
                 )

--- a/imod_coupler/drivers/ribametamod/config.py
+++ b/imod_coupler/drivers/ribametamod/config.py
@@ -20,7 +20,6 @@ class Coupling(BaseModel):
     mf6_passive_river_packages: dict[str, str]
     mf6_passive_drainage_packages: dict[str, str]
 
-    enable_sprinkling_groundwater: bool = False  # true when sprinkling is active
     mf6_msw_recharge_pkg: str = (
         ""  # the recharge package that will be used for coupling
     )
@@ -37,28 +36,12 @@ class Coupling(BaseModel):
     )
     output_config_file: FilePath | None = None
 
-    enable_sprinkling_surface_water: bool = False  # true when sprinkling is active
     rib_msw_sprinkling_map_surface_water: FilePath | None = (
         None  # the path to the sprinkling map file
     )
     rib_msw_ponding_map_surface_water: FilePath | None = (
         None  # the path to the ponding map file
     )
-
-    @field_validator("mf6_msw_well_pkg")
-    @classmethod
-    def validate_mf6_msw_well_pkg(
-        cls, mf6_msw_well_pkg: str | None, info: ValidationInfo
-    ) -> str | None:
-        assert info.config is not None
-        if (
-            info.config.get("enable_sprinkling_groundwater")
-            and mf6_msw_well_pkg is None
-        ):
-            raise ValueError(
-                "If `enable_sprinkling_groundwater` is True, then `mf6_msw_well_pkg` needs to be set."
-            )
-        return mf6_msw_well_pkg
 
     @field_validator(
         "output_config_file",
@@ -77,11 +60,11 @@ class Coupling(BaseModel):
     ) -> FilePath | None:
         assert info.config is not None
         if mf6_msw_sprinkling_map_groundwater is not None:
+            if info.config.get("mf6_msw_well_pkg") is None:
+                raise ValueError(
+                    "If 'mf6_msw_sprinkling_map_groundwater is set, then `mf6_msw_well_pkg` needs to be set."
+                )
             return mf6_msw_sprinkling_map_groundwater.resolve()
-        elif info.config.get("enable_sprinkling_groundwater"):
-            raise ValueError(
-                "If `enable_sprinkling_groundwater` is True, then `mf6_msw_sprinkling_map_groundwater` needs to be set."
-            )
         return mf6_msw_sprinkling_map_groundwater
 
 

--- a/imod_coupler/drivers/ribametamod/mapping.py
+++ b/imod_coupler/drivers/ribametamod/mapping.py
@@ -153,7 +153,7 @@ class SetMapping:
             "sum",
         )
 
-        if self.coupling.enable_sprinkling_groundwater:
+        if self.coupling.mf6_msw_sprinkling_map_groundwater is not None:
             assert isinstance(self.coupling.mf6_msw_well_pkg, str)
             assert isinstance(self.coupling.mf6_msw_sprinkling_map_groundwater, Path)
 

--- a/pre-processing/primod/driver_coupling/metamod.py
+++ b/pre-processing/primod/driver_coupling/metamod.py
@@ -100,11 +100,11 @@ class MetaModDriverCoupling(DriverCoupling):
         coupling_dict["mf6_msw_node_map"] = grid_mapping.write(directory)
         coupling_dict["mf6_msw_recharge_pkg"] = self.mf6_recharge_package
         coupling_dict["mf6_msw_recharge_map"] = rch_mapping.write(directory)
-        coupling_dict["enable_sprinkling"] = False
 
         if well_mapping is not None:
-            coupling_dict["enable_sprinkling"] = True
             coupling_dict["mf6_msw_well_pkg"] = self.mf6_wel_package
-            coupling_dict["mf6_msw_sprinkling_map"] = well_mapping.write(directory)
+            coupling_dict["mf6_msw_sprinkling_map_groundwater"] = well_mapping.write(
+                directory
+            )
 
         return coupling_dict

--- a/pre-processing/primod/ribametamod.py
+++ b/pre-processing/primod/ribametamod.py
@@ -174,7 +174,7 @@ class RibaMetaMod(CoupledModel):
                         ),
                     },
                 },
-                "coupling": coupling_dict,
+                "coupling": [coupling_dict],
             },
         }
 

--- a/tests/test_imod_coupler/test_config.py
+++ b/tests/test_imod_coupler/test_config.py
@@ -31,7 +31,7 @@ cases_missing_files = [
     ["driver", "kernels", "metaswap", "dll"],
     ["driver", "coupling", 0, "mf6_msw_node_map"],
     ["driver", "coupling", 0, "mf6_msw_recharge_map"],
-    ["driver", "coupling", 0, "mf6_msw_sprinkling_map"],
+    ["driver", "coupling", 0, "mf6_msw_sprinkling_map_groundwater"],
 ]
 
 
@@ -104,11 +104,9 @@ def test_sprinkling_requires_files(
     with open(config_path, "rb") as f:
         config_dict = tomli.load(f)
 
-    assert config_dict["driver"]["coupling"][0]["enable_sprinkling"]
-
     # Get the path of `mf6_msw_sprinkling_map`
     sprinkling_map = config_path.parent / get_from_container(
-        config_dict, ["driver", "coupling", 0, "mf6_msw_sprinkling_map"]
+        config_dict, ["driver", "coupling", 0, "mf6_msw_sprinkling_map_groundwater"]
     )
     # Delete `mf6_msw_sprinkling_map`
 

--- a/tests/test_imod_coupler/test_modstrip.py
+++ b/tests/test_imod_coupler/test_modstrip.py
@@ -20,7 +20,6 @@ def write_toml(
         "mf6_msw_node_map": "./NODENR2SVAT.DXC",
         "mf6_msw_recharge_pkg": "rch_msw",
         "mf6_msw_recharge_map": "./RCHINDEX2SVAT.DXC",
-        "enable_sprinkling": False,
     }
 
     coupler_toml = {

--- a/tests/test_primod/test_preprocessing_metamod.py
+++ b/tests/test_primod/test_preprocessing_metamod.py
@@ -188,9 +188,8 @@ def test_metamod_write_toml(prepared_msw_model, coupled_mf6_model, tmp_path):
         "mf6_msw_node_map": "./exchanges/nodenr2svat.dxc",
         "mf6_msw_recharge_map": "./exchanges/rchindex2svat.dxc",
         "mf6_msw_recharge_pkg": "rch_msw",
-        "enable_sprinkling": True,
         "mf6_msw_well_pkg": "wells_msw",
-        "mf6_msw_sprinkling_map": "./exchanges/wellindex2svat.dxc",
+        "mf6_msw_sprinkling_map_groundwater": "./exchanges/wellindex2svat.dxc",
     }
 
     coupled_models.write_toml(
@@ -238,9 +237,8 @@ def test_metamod_get_coupling_dict(prepared_msw_model, coupled_mf6_model, tmp_pa
         "mf6_msw_node_map": "./exchanges/nodenr2svat.dxc",
         "mf6_msw_recharge_map": "./exchanges/rchindex2svat.dxc",
         "mf6_msw_recharge_pkg": "rch_msw",
-        "enable_sprinkling": True,
         "mf6_msw_well_pkg": "wells_msw",
-        "mf6_msw_sprinkling_map": "./exchanges/wellindex2svat.dxc",
+        "mf6_msw_sprinkling_map_groundwater": "./exchanges/wellindex2svat.dxc",
     }
 
     coupled_dict = coupled_models.write_exchanges(
@@ -270,7 +268,6 @@ def test_metamod_get_coupling_dict_no_sprinkling(
         "mf6_msw_node_map": "./exchanges/nodenr2svat.dxc",
         "mf6_msw_recharge_map": "./exchanges/rchindex2svat.dxc",
         "mf6_msw_recharge_pkg": "rch_msw",
-        "enable_sprinkling": False,
     }
 
     coupled_dict = coupled_models.write_exchanges(


### PR DESCRIPTION
Base it off whether a map file is provided. Make names consistent between MetaMod and RibaMetaMod.