### PR TITLE
Fix failing teamcity configuration

### DIFF
--- a/.teamcity/iMOD6_IMOD6collectorDaily/project-config.xml
+++ b/.teamcity/iMOD6_IMOD6collectorDaily/project-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" parent-id="iMOD6_Coupler" uuid="49cd0606-a80d-4cac-8daf-970dab314190" xsi:noNamespaceSchemaLocation="https://www.jetbrains.com/teamcity/schemas/2021.1/project-config.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" parent-id="iMOD6_Coupler" uuid="49cd0606-a80d-4cac-8daf-970dab314191" xsi:noNamespaceSchemaLocation="https://www.jetbrains.com/teamcity/schemas/2021.1/project-config.xsd">
   <name>iMOD6_collector</name>
   <description>Collect iMOD6 coupled components + coupler into a single package</description>
   <parameters />


### PR DESCRIPTION
This commit fixes a failing build configuration.
The configuration was failing because it was lacking a unique uuid