### PR TITLE
re-added check on multiple user priorities per sprinkling user

### DIFF
--- a/imod_coupler/drivers/ribametamod/ribametamod.py
+++ b/imod_coupler/drivers/ribametamod/ribametamod.py
@@ -325,6 +325,17 @@ class RibaMetaMod(Driver):
                     self.coupled_priority_indices, _ = np.nonzero(
                         self.ribasim_user_demand[:, self.coupled_user_indices]
                     )
+
+                    # check for multiple priorities per user
+                    unique, counts = np.unique(
+                        self.coupled_user_indices, return_counts=True
+                    )
+                    too_many = unique[counts > 1] + 1
+                    if np.size(too_many) > 0:
+                        raise ValueError(
+                            f"More than one priority set for sprinkling user demands {too_many}."
+                        )
+
                     # zero all coupled demand elements
                     self.ribasim_user_demand[
                         self.coupled_priority_indices, self.coupled_user_indices


### PR DESCRIPTION
minor change re-adding check on the number of priorities in the user-demand matrix per sprinkling user. Seems to have been removed, but I think it can still be useful. 