### PR TITLE
Allow grid based basin and water user definitions and facilitate subsetting of subgrid-df

### DIFF
--- a/pre-processing/primod/driver_coupling/ribameta.py
+++ b/pre-processing/primod/driver_coupling/ribameta.py
@@ -6,6 +6,7 @@ import geopandas as gpd
 import imod
 import numpy as np
 import ribasim
+import xarray as xr
 from imod.msw import GridData, MetaSwapModel, Sprinkling
 
 from primod.driver_coupling.driver_coupling_base import DriverCoupling
@@ -15,7 +16,6 @@ from primod.driver_coupling.util import (
 )
 from primod.mapping.svat_basin_mapping import SvatBasinMapping
 from primod.mapping.svat_user_demand_mapping import SvatUserDemandMapping
-import xarray as xr
 
 
 class RibaMetaDriverCoupling(DriverCoupling):

--- a/pre-processing/primod/driver_coupling/ribameta.py
+++ b/pre-processing/primod/driver_coupling/ribameta.py
@@ -23,10 +23,10 @@ class RibaMetaDriverCoupling(DriverCoupling):
 
     Attributes
     ----------
-    basin_definition: gpd.GeoDataFrame
-        GeoDataFrame of basin polygons
-    user_demand_definition: gpd.GeoDataFrame
-        GeoDataFrame of user demand polygons
+    basin_definition: gpd.GeoDataFrame | xr.DataArray
+        GeoDataFrame of basin polygons or xr.DataArray with gridded basin nodes
+    user_demand_definition: gpd.GeoDataFrame| xr.DataArray
+        GeoDataFrame of user demand polygons or xr.DataArray with gridded demand nodes
     """
 
     ribasim_basin_definition: gpd.GeoDataFrame | xr.DataArray

--- a/pre-processing/primod/driver_coupling/ribameta.py
+++ b/pre-processing/primod/driver_coupling/ribameta.py
@@ -97,7 +97,7 @@ class RibaMetaDriverCoupling(DriverCoupling):
             else:
                 raise TypeError(
                     "Expected geopandas.GeoDataFrame or xr.Dataset: "
-                    f"received {type(self.ribasim_user_demand_definition.__name__)}"
+                    f"received {type(self.ribasim_user_demand_definition.__name__)}"  # type: ignore
                 )
             # sprinkling surface water for subsection of svats determined in 'sprinkling'
             swspr_grid_data = copy.deepcopy(msw_model[grid_data_key])

--- a/pre-processing/primod/driver_coupling/ribamod.py
+++ b/pre-processing/primod/driver_coupling/ribamod.py
@@ -24,18 +24,15 @@ class RibaModDriverCoupling(DriverCoupling, abc.ABC):
     ----------
     mf6_model: str
         The name of the GWF model
-    ribasim_basin_definition : gpd.GeoDataFrame, xr.Dataset
+    ribasim_basin_definition : gpd.GeoDataFrame | xr.Dataset
         * GeoDataFrame: basin polygons
         * Dataset: mapping of mf6 package name to grid containing basin IDs.
     mf6_packages : list of str
         A list of river or drainage packages.
-    subgrid_id_range: optional DataFrame containing min and max subgrid_id per mf6_package
     """
 
     mf6_model: str
-    ribasim_basin_definition: (
-        gpd.GeoDataFrame | xr.Dataset
-    )  # TODO: hopefully pydantic is happy
+    ribasim_basin_definition: gpd.GeoDataFrame | xr.Dataset
     mf6_packages: list[str]
     subgrid_id_range: pd.DataFrame | None = None
 

--- a/pre-processing/primod/driver_coupling/ribamod.py
+++ b/pre-processing/primod/driver_coupling/ribamod.py
@@ -162,15 +162,14 @@ class RibaModDriverCoupling(DriverCoupling, abc.ABC):
                 raise TypeError(
                     f"Expected Drainage packages for passive coupling, received: {type(package).__name__}"
                 )
-
-            #  check on the bottom elevation and ribasim minimal subgrid level
-            minimum_subgrid_level = (
-                ribasim_model.basin.subgrid.df.groupby("subgrid_id")
-                .min()["subgrid_level"]
-                .to_numpy()
-            )
             # in active coupling, check subgrid levels versus modflow bottom elevation
             if isinstance(self, RibaModActiveDriverCoupling):
+                #  check on the bottom elevation and ribasim minimal subgrid level
+                minimum_subgrid_level = (
+                    ribasim_model.basin.subgrid.df.groupby("subgrid_id")  # type: ignore
+                    .min()["subgrid_level"]
+                    .to_numpy()
+                )
                 subgrid_index = mapping.dataframe["subgrid_index"]
                 bound_index = mapping.dataframe["bound_index"]
                 bottom_elevation = package["bottom_elevation"].to_numpy()

--- a/pre-processing/primod/driver_coupling/ribamod.py
+++ b/pre-processing/primod/driver_coupling/ribamod.py
@@ -226,16 +226,12 @@ class RibaModActiveDriverCoupling(RibaModDriverCoupling):
         ribasim_model: ribasim.Model,
     ) -> ActiveNodeBasinMapping:
         subgrid_df = self._validate_subgrid_df(ribasim_model)
-        subgrid_id_range = self.subgrid_id_range
-        if self.subgrid_id_range is not None:
-            subgrid_id_range = self.subgrid_id_range.loc[name]
         return ActiveNodeBasinMapping(
             name=name,
             conductance=conductance,
             gridded_basin=gridded_basin,
             basin_ids=basin_ids,
             subgrid_df=subgrid_df,
-            subgrid_id_range=subgrid_id_range,
         )
 
 

--- a/pre-processing/primod/mapping/node_basin_mapping.py
+++ b/pre-processing/primod/mapping/node_basin_mapping.py
@@ -196,7 +196,7 @@ class ActiveNodeBasinMapping(NodeBasinMapping):
 
 def validate_meta_label_column(name: str, subgrid_df: pd.DataFrame) -> None:
     if "meta_label" in subgrid_df.columns:
-        if (subgrid_df["meta_label"] != name).any():
+        if (subgrid_df["meta_label"] != name).all():
             raise ValueError(
                 "if column 'meta_label' is defined in subgrid dataframe, all actively coupled packages should be included"
             )

--- a/pre-processing/primod/mapping/node_basin_mapping.py
+++ b/pre-processing/primod/mapping/node_basin_mapping.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -7,7 +9,6 @@ from scipy.spatial import KDTree
 
 from primod.mapping.mappingbase import GenericMapping
 from primod.typing import Bool, Float, Int
-from typing import Union
 
 
 class NodeBasinMapping(GenericMapping):
@@ -116,7 +117,6 @@ class ActiveNodeBasinMapping(NodeBasinMapping):
         gridded_basin: gpd.GeoDataFrame,
         basin_ids: pd.Series,
         subgrid_df: pd.DataFrame,
-        subgrid_id_range: pd.DataFrame | None,
     ):
         # Use xarray.where() to force the dimension order of conductance, rather than
         # using gridded_basin.where() (which prioritizes the gridded_basin dims)
@@ -126,7 +126,9 @@ class ActiveNodeBasinMapping(NodeBasinMapping):
         )
         boundary_index = self._derive_boundary_index(conductance, include)
         # Match the cells to the subgrid based on xy location.
-        subgrid_xy, subgrid_id = self._get_subgrid_xy(subgrid_df, subgrid_id_range)
+        if "meta_label" in subgrid_df.columns:
+            subgrid_df = subgrid_df[subgrid_df["meta_label"] == name]
+        subgrid_xy, subgrid_id = self._get_subgrid_xy(subgrid_df)
         conductance_xy = self._get_conductance_xy(conductance, include)
         xy_index = self._find_nearest_subgrid_elements(subgrid_xy, conductance_xy)
         self.name = name
@@ -139,9 +141,7 @@ class ActiveNodeBasinMapping(NodeBasinMapping):
         )
 
     @staticmethod
-    def _get_subgrid_xy(
-        subgrid: pd.DataFrame, subgrid_id_range: pd.DataFrame | None
-    ) -> Union[NDArray[Float], NDArray[Float]]:
+    def _get_subgrid_xy(subgrid: pd.DataFrame) -> Union[NDArray[Float], NDArray[Float]]:
         # Check whether columns (optional to Ribasim) are present.
         if "meta_x" not in subgrid or "meta_y" not in subgrid:
             raise ValueError(
@@ -149,13 +149,6 @@ class ActiveNodeBasinMapping(NodeBasinMapping):
                 "ribasim.Model.basin.subgrid dataframe for actively coupled river "
                 f"and drainage packages. Found columns: {subgrid.columns}"
             )
-        # Update for optional subgrid id-range
-        if subgrid_id_range is not None:
-            min_id = subgrid_id_range["min_id"]
-            max_id = subgrid_id_range["max_id"]
-            subgrid = subgrid[subgrid["subgrid_id"].ge(min_id)]
-            subgrid = subgrid[subgrid["subgrid_id"].lt(max_id)]
-
         # Check x and y coordinates for uniqueness
         grouped = subgrid.groupby("subgrid_id")
         multiple_x = grouped["meta_x"].nunique().ne(1)
@@ -166,7 +159,7 @@ class ActiveNodeBasinMapping(NodeBasinMapping):
             raise ValueError(
                 "Subgrid data contains multiple values for meta_x or meta_y "
                 f"for subgrid_id(s):\n   meta_x: {x_ids}\n   meta_y: {y_ids} \n"
-                "try using the 'subgrid_id_range' argument"
+                "try using a 'meta_label' column to deal with stacked elements"
             )
         x = grouped["meta_x"].first().to_numpy()
         y = grouped["meta_y"].first().to_numpy()

--- a/tests/test_primod/test_ribamod_exchange_creator.py
+++ b/tests/test_primod/test_ribamod_exchange_creator.py
@@ -168,11 +168,12 @@ def test_get_subgrid_xy():
     df = pd.DataFrame(
         data={
             "subgrid_id": [1, 1, 2, 2],
+            "subgrid_index": [0, 0, 1, 1],
             "meta_x": [1.0, 1.0, 2.0, 2.0],
             "meta_y": [1.0, 1.0, 2.0, 2.0],
         }
     )
-    xy, subgrid_id = ActiveNodeBasinMapping._get_subgrid_xy(df)
+    xy, subgrid_index = ActiveNodeBasinMapping._get_subgrid_xy(df)
     assert np.allclose(
         xy,
         [
@@ -180,7 +181,7 @@ def test_get_subgrid_xy():
             [2.0, 2.0],
         ],
     )
-    assert np.allclose(subgrid_id, [1, 2])
+    assert np.allclose(subgrid_index, [0, 1])
 
 
 def test_get_conductance_xy():
@@ -260,7 +261,7 @@ def test_node_basin_mapping_stacked() -> None:
 
     #        subgrid id:  |   |   |   |   |   |
     #                     |   |   |   |   |   |
-    #                     |0,1|2,3|4,5|6,7|8,9|
+    #                     |1,2|3,4|5,6|7,8|9,10|
     #                     |   |   |   |   |   |
 
     #
@@ -290,7 +291,7 @@ def test_node_basin_mapping_stacked() -> None:
     subgrid_df = pd.DataFrame(
         data={
             "node_id": np.array([1, 1, 2, 2, 2, 1, 1, 2, 2, 2]),
-            "subgrid_id": np.arange(10),
+            "subgrid_id": np.arange(10) + 1,
             "subgrid_level": np.array(
                 [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
             ),
@@ -360,7 +361,7 @@ def test_node_basin_mapping_stacked_no_label() -> None:
         data={
             "node_id": np.array([1] * 10),
             "subgrid_id": np.arange(10),
-            "subgrid_level": np.array([1.0] * 10),
+            "subgrid_level": np.array([1.0] * 10) + 1,
             "meta_x": np.array([0.5, 0.5, 1.5, 1.5, 2.5, 2.5, 3.5, 3.5, 4.5, 4.5]),
             "meta_y": np.array([11.5] * 10),
             "meta_label": np.array(["sys1"] * 10),

--- a/tests/test_primod/test_ribamod_exchange_creator.py
+++ b/tests/test_primod/test_ribamod_exchange_creator.py
@@ -172,7 +172,7 @@ def test_get_subgrid_xy():
             "meta_y": [1.0, 1.0, 2.0, 2.0],
         }
     )
-    xy = ActiveNodeBasinMapping._get_subgrid_xy(df)
+    xy, subgrid_id = ActiveNodeBasinMapping._get_subgrid_xy(df)
     assert np.allclose(
         xy,
         [
@@ -180,6 +180,7 @@ def test_get_subgrid_xy():
             [2.0, 2.0],
         ],
     )
+    assert np.allclose(subgrid_id, [1, 2])
 
 
 def test_get_conductance_xy():
@@ -249,3 +250,125 @@ def test_derive_active_coupling():
         ),
         check_dtype=False,  # int32 versus int64 ...
     )
+
+
+def test_node_basin_mapping_stacked() -> None:
+    #  basin definition:  | 1 | 1 | 2 | 2 | 2 |
+    #                     | 1 | 1 | 2 | 2 | 2 |
+    #                     | 1 | 1 | 2 | 2 | 2 |
+    #                     | 1 | 1 | 2 | 2 | 2 |
+
+    #        subgrid id:  |   |   |   |   |   |
+    #                     |   |   |   |   |   |
+    #                     |0,1|2,3|4,5|6,7|8,9|
+    #                     |   |   |   |   |   |
+
+    #
+    #        cond sys 1:  |   |   |   |   |   |
+    #                     |   |   |   |   |   |
+    #                     | x | x | x | x | x |
+    #                     |   |   |   |   |   |
+
+    #        cond sys 2:  |   |   |   |   |   |
+    #                     |   |   |   |   |   |
+    #                     |   |   | x | x | x |
+    #                     |   |   |   |   |   |
+
+    # sys1: subgrid elements 0, 2, 4, 6, 8 should be coupled
+    # sys2: subgrid elements 5, 7, 9 should be coupled
+
+    cond1 = xr.full_like(conductance().isel(layer=0, drop=True), 1.0)
+    cond1[0:2, :] = np.nan
+    cond1[3, :] = np.nan
+
+    cond2 = cond1.copy()
+    cond2[2, 0:2] = np.nan
+
+    gridded_basin = xr.full_like(cond1, 1)
+    gridded_basin[:, 2:5] = 2
+    basin_ids = pd.Series([1, 2])
+    subgrid_df = pd.DataFrame(
+        data={
+            "node_id": np.array([1, 1, 2, 2, 2, 1, 1, 2, 2, 2]),
+            "subgrid_id": np.arange(10),
+            "subgrid_level": np.array(
+                [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+            ),
+            "meta_x": np.array([0.5, 0.5, 1.5, 1.5, 2.5, 2.5, 3.5, 3.5, 4.5, 4.5]),
+            "meta_y": np.array([11.5] * 10),
+            "meta_label": np.array(
+                [
+                    "sys1",
+                    "sys2",
+                    "sys1",
+                    "sys2",
+                    "sys1",
+                    "sys2",
+                    "sys1",
+                    "sys2",
+                    "sys1",
+                    "sys2",
+                ]
+            ),
+        }
+    )
+    # check results for sys1
+    mapping = ActiveNodeBasinMapping(
+        "sys1", cond1, gridded_basin, basin_ids, subgrid_df
+    )
+    assert mapping.name == "sys1"
+    table = mapping.dataframe
+    assert isinstance(table, pd.DataFrame)
+    assert table.shape == (5, 3)
+    pd.testing.assert_frame_equal(
+        table,
+        pd.DataFrame(
+            data={
+                "basin_index": [0, 0, 1, 1, 1],
+                "bound_index": [0, 1, 2, 3, 4],
+                "subgrid_index": [0, 2, 4, 6, 8],
+            }
+        ),
+        check_dtype=False,  # int32 versus int64 ...
+    )
+    # and sys2
+    mapping = ActiveNodeBasinMapping(
+        "sys2", cond2, gridded_basin, basin_ids, subgrid_df
+    )
+    assert mapping.name == "sys2"
+    table = mapping.dataframe
+    assert isinstance(table, pd.DataFrame)
+    assert table.shape == (3, 3)
+    pd.testing.assert_frame_equal(
+        table,
+        pd.DataFrame(
+            data={
+                "basin_index": [1, 1, 1],
+                "bound_index": [0, 1, 2],
+                "subgrid_index": [5, 7, 9],
+            }
+        ),
+        check_dtype=False,  # int32 versus int64 ...
+    )
+
+
+def test_node_basin_mapping_stacked_no_label() -> None:
+    cond = xr.full_like(conductance().isel(layer=0, drop=True), 1.0)
+    gridded_basin = xr.full_like(cond, 1)
+    basin_ids = pd.Series([1])
+    subgrid_df = pd.DataFrame(
+        data={
+            "node_id": np.array([1] * 10),
+            "subgrid_id": np.arange(10),
+            "subgrid_level": np.array([1.0] * 10),
+            "meta_x": np.array([0.5, 0.5, 1.5, 1.5, 2.5, 2.5, 3.5, 3.5, 4.5, 4.5]),
+            "meta_y": np.array([11.5] * 10),
+            "meta_label": np.array(["sys1"] * 10),
+        }
+    )
+    _ = ActiveNodeBasinMapping("sys1", cond, gridded_basin, basin_ids, subgrid_df)
+    with pytest.raises(
+        ValueError,
+        match="if column 'meta_label' is defined in subgrid dataframe, all actively coupled packages should be included",
+    ):
+        ActiveNodeBasinMapping("sys2", cond, gridded_basin, basin_ids, subgrid_df)


### PR DESCRIPTION
The driver_couplings related to Ribasim can now contain grid-based basin and water user definition. This gives the optional ```xr.Dataset``` or ```xr.DataArray```.

- ```xr.Dataset``` in ```primod.driver_coupling.RibaModDriverCoupling```:  per mf-package  a basin definition data variable
```xr.DataArray```  in ```primod.driver_coupling.RibaMetaDriverCoupling```: per (single) basin definition and (single) water user definition.

In the ```primod.driver_coupling.ActiveNodeBasinMapping``` an optional subsetting is possible to deal with stacked subgrid points. Subsetting is done via the optional ‘meta_label’ column in the subgrid.df 
