### PR TITLE
name change ribasim user demand priority

### DIFF
--- a/tests/test_imod_coupler/test_ribametamod_cases.py
+++ b/tests/test_imod_coupler/test_ribametamod_cases.py
@@ -106,7 +106,7 @@ def add_water_users(ribasim_model: ribasim.Model) -> ribasim.Model:
                 active=True,
                 return_factor=[0.0],
                 min_level=[-999.0],
-                priority=[1],
+                demand_priority=[1],
             ),
         ],
     )
@@ -118,7 +118,7 @@ def add_water_users(ribasim_model: ribasim.Model) -> ribasim.Model:
                 active=True,
                 return_factor=[0.0, 0.0],
                 min_level=[-999.0, -999.0],
-                priority=[4, 8],
+                demand_priority=[4, 8],
             ),
         ],
     )
@@ -131,7 +131,7 @@ def add_water_users(ribasim_model: ribasim.Model) -> ribasim.Model:
                 active=True,
                 return_factor=[0.0],
                 min_level=[-999.0],
-                priority=[3],
+                demand_priority=[3],
             ),
         ],
     )
@@ -148,7 +148,7 @@ def add_water_users(ribasim_model: ribasim.Model) -> ribasim.Model:
     # add default level-control to basins
     ribasim_model.level_demand.add(
         ribasim.Node(10, Point(240.0, 10.0), subnetwork_id=2),
-        [level_demand.Static(priority=[1], min_level=[-1.0e6], max_level=[-1.0e6])],
+        [level_demand.Static(demand_priority=[1], min_level=[-1.0e6], max_level=[-1.0e6])],
     )
     ribasim_model.edge.add(
         ribasim_model.level_demand[10],
@@ -156,7 +156,7 @@ def add_water_users(ribasim_model: ribasim.Model) -> ribasim.Model:
     )
     ribasim_model.level_demand.add(
         ribasim.Node(11, Point(740.0, 10.0), subnetwork_id=3),
-        [level_demand.Static(priority=[1], min_level=[-1.0e6], max_level=[-1.0e6])],
+        [level_demand.Static(demand_priority=[1], min_level=[-1.0e6], max_level=[-1.0e6])],
     )
     ribasim_model.edge.add(
         ribasim_model.level_demand[11],


### PR DESCRIPTION
name 'priority' for a user demand in Ribasim is nowadays renamed 'demand_priority'