### PR TITLE
Add missing agent requirement

### DIFF
--- a/.teamcity/_Self/buildTypes/Lint.kt
+++ b/.teamcity/_Self/buildTypes/Lint.kt
@@ -31,4 +31,8 @@ object Lint : BuildType({
             formatStderrAsError = true
         }
     }
+
+    requirements {
+        equals("env.OS", "Windows_NT")
+    }
 })

--- a/.teamcity/_Self/buildTypes/MyPy.kt
+++ b/.teamcity/_Self/buildTypes/MyPy.kt
@@ -56,4 +56,8 @@ object MyPy : BuildType({
             rules = "imod_coupler/*.xml"
         }
     }
+
+    requirements {
+        equals("env.OS", "Windows_NT")
+    }
 })


### PR DESCRIPTION
The lint and mypy CI steps don't have a agent requirment
As a result they are sometimes started on agents that don't have pixi installed.
This PR fixes the build steps to a suitable agent