### PR TITLE
Cleanup teamcity

### DIFF
--- a/.teamcity/IMODCollector/Project.kt
+++ b/.teamcity/IMODCollector/Project.kt
@@ -1,49 +1,17 @@
 package IMODCollector
 
-import IMODCollector.buildTypes.*
-import jetbrains.buildServer.configs.kotlin.BuildType
-
+import IMODCollector.buildTypes.Coupler_Regression_Binaries
+import IMODCollector.buildTypes.IMODCollector_X64development
+import IMODCollector.buildTypes.Ribasim_binaries
 import jetbrains.buildServer.configs.kotlin.Project
-import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object Project : Project({
     id("IMODCollector")
     name = "iMOD_Collector"
     description = "Collect iMOD6 coupled components + coupler into a single package"
+
     buildType(IMODCollector_X64development)
     buildType(Ribasim_binaries)
     buildType(Coupler_Regression_Binaries)
 })
 
-object Ribasim_binaries : BuildType({
-    name = "Ribasim binaries"
-    description = "Download Ribasim release binaries"
-
-    artifactRules = """
-        ribasim/** => ribasim.zip!
-    """.trimIndent()
-
-    params {
-        select("RIBASIM_Platform", "",
-            options = listOf("windows", "linux"))
-        select("RIBASIM_Version", "",
-            options = listOf("v2025.6.0", "v2025.5.0", "v2025.4.0", "v2025.3.0"))
-    }
-
-    vcs {
-    }
-
-    steps {
-        script {
-            name = "Download Ribasim"
-            scriptContent = """
-                wget https://github.com/Deltares/Ribasim/releases/download/%RIBASIM_Version%/ribasim_%RIBASIM_Platform%.zip -O ribasim.zip
-                unzip  "ribasim.zip"
-            """.trimIndent()
-        }
-    }
-
-    requirements {
-        equals("teamcity.agent.jvm.os.name", "Linux")
-    }
-})

--- a/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
+++ b/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
@@ -1,18 +1,20 @@
 package IMODCollector.buildTypes
 
+import Templates.GitHubIntegrationTemplate
 import _Self.buildTypes.Lint
 import _Self.buildTypes.MyPy
 import _Self.buildTypes.TwineCheck
 import _Self.vcsRoots.ImodCoupler
-import jetbrains.buildServer.configs.kotlin.*
-import jetbrains.buildServer.configs.kotlin.buildFeatures.PullRequests
-import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
-import jetbrains.buildServer.configs.kotlin.buildFeatures.pullRequests
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object IMODCollector_X64development : BuildType({
     name = "x64_development"
     description = "Collect all Release_x64 kernels in the iMOD6 suite"
+
+    templates(GitHubIntegrationTemplate)
 
     artifactRules = """
         coupler/dist/ => imod_collector.zip!/
@@ -30,7 +32,7 @@ object IMODCollector_X64development : BuildType({
     }
 
     vcs {
-        root(_Self.vcsRoots.ImodCoupler, "+:. => ./coupler")
+        root(ImodCoupler, "+:. => ./coupler")
 
         cleanCheckout = true
     }
@@ -57,27 +59,6 @@ object IMODCollector_X64development : BuildType({
             name = "Get version from imod coupler"
             workingDir = "coupler"
             scriptContent = """call dist\imodc --version"""
-        }
-    }
-
-    features {
-        commitStatusPublisher {
-            vcsRootExtId = "${ImodCoupler.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:6b37af71-1f2f-4611-8856-db07965445c0"
-                }
-            }
-        }
-        pullRequests {
-            vcsRootExtId = "${ImodCoupler.id}"
-            provider = github {
-                authType = token {
-                    token = "credentialsJSON:71420214-373c-4ccd-ba32-2ea886843f62"
-                }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-            }
         }
     }
 

--- a/.teamcity/IMODCollector/buildTypes/RibasimBinaries.kt
+++ b/.teamcity/IMODCollector/buildTypes/RibasimBinaries.kt
@@ -1,0 +1,37 @@
+package IMODCollector.buildTypes
+
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+
+object Ribasim_binaries : BuildType({
+    name = "Ribasim binaries"
+    description = "Download Ribasim release binaries"
+
+    artifactRules = """
+        ribasim/** => ribasim.zip!
+    """.trimIndent()
+
+    params {
+        select("RIBASIM_Platform", "",
+            options = listOf("windows", "linux"))
+        select("RIBASIM_Version", "",
+            options = listOf("v2025.6.0", "v2025.5.0", "v2025.4.0", "v2025.3.0"))
+    }
+
+    vcs {
+    }
+
+    steps {
+        script {
+            name = "Download Ribasim"
+            scriptContent = """
+                wget https://github.com/Deltares/Ribasim/releases/download/%RIBASIM_Version%/ribasim_%RIBASIM_Platform%.zip -O ribasim.zip
+                unzip  "ribasim.zip"
+            """.trimIndent()
+        }
+    }
+
+    requirements {
+        equals("teamcity.agent.jvm.os.name", "Linux")
+    }
+})

--- a/.teamcity/Templates/GitHubIntegrationTemplate.kt
+++ b/.teamcity/Templates/GitHubIntegrationTemplate.kt
@@ -1,0 +1,21 @@
+package Templates
+
+import _Self.vcsRoots.ImodCoupler
+import jetbrains.buildServer.configs.kotlin.Template
+import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
+
+object GitHubIntegrationTemplate : Template({
+    name = "GitHubIntegrationTemplate"
+
+    features {
+        commitStatusPublisher {
+            vcsRootExtId = "${ImodCoupler.id}"
+            publisher = github {
+                githubUrl = "https://api.github.com"
+                authType = personalToken {
+                    token = "credentialsJSON:6b37af71-1f2f-4611-8856-db07965445c0"
+                }
+            }
+        }
+    }
+})

--- a/.teamcity/_Self/Project.kt
+++ b/.teamcity/_Self/Project.kt
@@ -1,5 +1,6 @@
 package _Self
 
+import Templates.GitHubIntegrationTemplate
 import _Self.buildTypes.TestPrimodWin64
 import _Self.buildTypes.*
 import _Self.vcsRoots.*
@@ -14,6 +15,8 @@ object Project : Project({
 
     vcsRoot(MetaSwapLookupTable)
     vcsRoot(ImodCoupler)
+
+    template(GitHubIntegrationTemplate)
 
     buildType(Lint)
     buildType(MyPy)

--- a/.teamcity/_Self/buildTypes/Lint.kt
+++ b/.teamcity/_Self/buildTypes/Lint.kt
@@ -1,15 +1,17 @@
 package _Self.buildTypes
 
+import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.BuildType
-import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object Lint : BuildType({
     name = "Lint"
 
+    templates(GitHubIntegrationTemplate)
+
     vcs {
-        root(_Self.vcsRoots.ImodCoupler, ". => imod_coupler")
+        root(ImodCoupler, ". => imod_coupler")
         cleanCheckout = true
     }
 
@@ -31,19 +33,6 @@ object Lint : BuildType({
                     pixi run --environment dev --frozen ruff
                 """.trimIndent()
             formatStderrAsError = true
-        }
-    }
-
-    features {
-        commitStatusPublisher {
-            id = "BUILD_EXT_142"
-            vcsRootExtId = "${ImodCoupler.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:6b37af71-1f2f-4611-8856-db07965445c0"
-                }
-            }
         }
     }
 

--- a/.teamcity/_Self/buildTypes/MyPy.kt
+++ b/.teamcity/_Self/buildTypes/MyPy.kt
@@ -1,9 +1,9 @@
 package _Self.buildTypes
 
+import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.buildFeatures.XmlReport
-import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.failureConditions.BuildFailureOnMetric
@@ -12,8 +12,10 @@ import jetbrains.buildServer.configs.kotlin.failureConditions.failOnMetricChange
 object MyPy : BuildType({
     name = "MyPy"
 
+    templates(GitHubIntegrationTemplate)
+
     vcs {
-        root(_Self.vcsRoots.ImodCoupler, ". => imod_coupler")
+        root(ImodCoupler, ". => imod_coupler")
         cleanCheckout = true
     }
 
@@ -53,17 +55,6 @@ object MyPy : BuildType({
     }
 
     features {
-        commitStatusPublisher {
-            id = "BUILD_EXT_142"
-            vcsRootExtId = "${ImodCoupler.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:6b37af71-1f2f-4611-8856-db07965445c0"
-                }
-            }
-        }
-
         xmlReport {
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod_coupler/*.xml"

--- a/.teamcity/_Self/buildTypes/TestPrimodWin64.kt
+++ b/.teamcity/_Self/buildTypes/TestPrimodWin64.kt
@@ -1,18 +1,21 @@
 package _Self.buildTypes
 
-import IMODCollector.buildTypes.Coupler_Regression_Binaries
 import IMODCollector.buildTypes.IMODCollector_X64development
+import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import _Self.vcsRoots.MetaSwapLookupTable
-import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.FailureAction
+import jetbrains.buildServer.configs.kotlin.PublishMode
 import jetbrains.buildServer.configs.kotlin.buildFeatures.XmlReport
-import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object TestPrimodWin64 : BuildType({
     name = "Test Primod Win64"
     description = "Win64 Regression testbench for MODFLOW6/MetaSWAP coupler"
+
+    templates(GitHubIntegrationTemplate)
 
     publishArtifacts = PublishMode.ALWAYS
 
@@ -55,16 +58,6 @@ object TestPrimodWin64 : BuildType({
     }
 
     features {
-        commitStatusPublisher {
-            id = "BUILD_EXT_142"
-            vcsRootExtId = "${ImodCoupler.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:6b37af71-1f2f-4611-8856-db07965445c0"
-                }
-            }
-        }
         xmlReport {
             id = "BUILD_EXT_145"
             reportType = XmlReport.XmlReportType.JUNIT

--- a/.teamcity/_Self/buildTypes/TestbenchCouplerWin64.kt
+++ b/.teamcity/_Self/buildTypes/TestbenchCouplerWin64.kt
@@ -1,10 +1,13 @@
 package _Self.buildTypes
 
 import IMODCollector.buildTypes.Coupler_Regression_Binaries
+import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
-import jetbrains.buildServer.configs.kotlin.*
+import _Self.vcsRoots.MetaSwapLookupTable
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.FailureAction
+import jetbrains.buildServer.configs.kotlin.PublishMode
 import jetbrains.buildServer.configs.kotlin.buildFeatures.XmlReport
-import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
@@ -12,6 +15,8 @@ import jetbrains.buildServer.configs.kotlin.buildSteps.script
 object TestbenchCouplerWin64 : BuildType({
     name = "Testbench Coupler Win64"
     description = "Win64 Regression testbench for MODFLOW6/MetaSWAP coupler"
+
+    templates(GitHubIntegrationTemplate)
 
     artifactRules = """imod_coupler\tests\temp => test_output.zip"""
     publishArtifacts = PublishMode.ALWAYS
@@ -43,8 +48,8 @@ object TestbenchCouplerWin64 : BuildType({
     }
 
     vcs {
-        root(_Self.vcsRoots.ImodCoupler, ". => imod_coupler")
-        root(_Self.vcsRoots.MetaSwapLookupTable, ". => lookup_table")
+        root(ImodCoupler, ". => imod_coupler")
+        root(MetaSwapLookupTable, ". => lookup_table")
 
         cleanCheckout = true
         branchFilter = """
@@ -73,15 +78,6 @@ object TestbenchCouplerWin64 : BuildType({
     }
 
     features {
-        commitStatusPublisher {
-            vcsRootExtId = "${ImodCoupler.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:6b37af71-1f2f-4611-8856-db07965445c0"
-                }
-            }
-        }
         xmlReport {
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod_coupler/report.xml"

--- a/.teamcity/_Self/buildTypes/TwineCheck.kt
+++ b/.teamcity/_Self/buildTypes/TwineCheck.kt
@@ -1,12 +1,14 @@
 package _Self.buildTypes
 
+import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.BuildType
-import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object TwineCheck : BuildType({
     name = "Twine"
+
+    templates(GitHubIntegrationTemplate)
 
     vcs {
         root(ImodCoupler, ". => imod_coupler")
@@ -22,19 +24,6 @@ object TwineCheck : BuildType({
                     pixi run check-package-primod
                 """.trimIndent()
             formatStderrAsError = true
-        }
-    }
-
-    features {
-        commitStatusPublisher {
-            id = "BUILD_EXT_142"
-            vcsRootExtId = "${ImodCoupler.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:6b37af71-1f2f-4611-8856-db07965445c0"
-                }
-            }
         }
     }
 

--- a/.teamcity/_Self/vcsRoots/ImodCoupler.kt
+++ b/.teamcity/_Self/vcsRoots/ImodCoupler.kt
@@ -1,6 +1,5 @@
 package _Self.vcsRoots
 
-import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 
 object ImodCoupler : GitVcsRoot({
@@ -13,7 +12,7 @@ object ImodCoupler : GitVcsRoot({
         -:refs/heads/gh-pages
     """.trimIndent()
     useTagsAsBranches = true
-    checkoutPolicy = GitVcsRoot.AgentCheckoutPolicy.USE_MIRRORS
+    checkoutPolicy = AgentCheckoutPolicy.USE_MIRRORS
     authMethod = password {
         userName = "teamcity-deltares"
         password = "credentialsJSON:abf605ce-e382-4b10-b5de-8a7640dc58d9"

--- a/.teamcity/_Self/vcsRoots/MetaSwapLookupTable.kt
+++ b/.teamcity/_Self/vcsRoots/MetaSwapLookupTable.kt
@@ -1,6 +1,5 @@
 package _Self.vcsRoots
 
-import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.vcs.SvnVcsRoot
 
 object MetaSwapLookupTable : SvnVcsRoot({


### PR DESCRIPTION
This commit cleans up the TeamCity kotlin files.
- A Github template is created to avoid duplicate code
- Unused references are removed
- The Ribasim binaries build is moved to a separate file