### PR TITLE
Issue #449 Add a sonarqube buildstep to the TeamCity pipeline

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,0 @@
-sonar.projectKey=Deltares_imod_coupler
-sonar.organization=deltares
-sonar.tests=tests

--- a/.teamcity/_Self/Project.kt
+++ b/.teamcity/_Self/Project.kt
@@ -3,6 +3,7 @@ package _Self
 import Pixi.PixiProject
 import Templates.GitHubIntegrationTemplate
 import _Self.buildTypes.TestPrimodWin64
+import _Self.buildTypes.SonarCloud
 import _Self.buildTypes.*
 import _Self.vcsRoots.*
 import Weekly.WeeklyProject
@@ -25,6 +26,7 @@ object Project : Project({
     buildType(TwineCheck)
     buildType(TestbenchCouplerWin64)
     buildType(TestPrimodWin64)
+    buildType(SonarCloud)
     buildType(Main)
 
     subProject(IMODCollector.Project)
@@ -72,6 +74,10 @@ object Main : BuildType({
         snapshot(TestPrimodWin64)
         {
             onDependencyFailure = FailureAction.FAIL_TO_START
+        }
+
+        snapshot(SonarCloud) {
+            onDependencyFailure = FailureAction.ADD_PROBLEM
         }
     }
 })

--- a/.teamcity/_Self/buildTypes/SonarCloud.kt
+++ b/.teamcity/_Self/buildTypes/SonarCloud.kt
@@ -3,6 +3,7 @@ package _Self.buildTypes
 import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object SonarCloud : BuildType({
     name = "SonarCloud"
@@ -11,7 +12,7 @@ object SonarCloud : BuildType({
     templates(GitHubIntegrationTemplate)
 
     params {
-        password("sonar_token", "%sonar_token%")
+        param("sonar_scanner_version", "8.0.1.6346")
     }
 
     vcs {
@@ -20,13 +21,15 @@ object SonarCloud : BuildType({
     }
 
     steps {
-        step {
+        script {
             name = "SonarCloud analysis"
             id = "Sonar_analysis"
-            type = "sonar-plugin"
-            param("teamcity.build.workingDir", "imod_coupler")
-            param("additionalParameters", "-Dproject.settings=imod_coupler/myproject.properties")
-            param("sonarServer", "54d6c253-800e-4025-870b-cb760324147b")
+            workingDir = "imod_coupler"
+            scriptContent = """
+                curl -sSL "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-%sonar_scanner_version%-windows-x64.zip" -o sonar-cli.zip
+                tar -xf sonar-cli.zip
+                sonar-scanner-%sonar_scanner_version%-windows-x64\bin\sonar-scanner.bat "-Dsonar.token=%sonar_token%"
+            """.trimIndent()
         }
     }
 

--- a/.teamcity/_Self/buildTypes/SonarCloud.kt
+++ b/.teamcity/_Self/buildTypes/SonarCloud.kt
@@ -24,7 +24,6 @@ object SonarCloud : BuildType({
             name = "SonarCloud analysis"
             id = "Sonar_analysis"
             type = "sonar-plugin"
-            param("teamcity.build.workingDir", "imod_coupler")
             param("sonarServer", "54d6c253-800e-4025-870b-cb760324147b")
         }
     }

--- a/.teamcity/_Self/buildTypes/SonarCloud.kt
+++ b/.teamcity/_Self/buildTypes/SonarCloud.kt
@@ -3,6 +3,7 @@ package _Self.buildTypes
 import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object SonarCloud : BuildType({
     name = "SonarCloud"
@@ -10,29 +11,25 @@ object SonarCloud : BuildType({
 
     templates(GitHubIntegrationTemplate)
 
+    params {
+        param("sonar_scanner_version", "8.0.1.6346")
+    }
+
     vcs {
         root(ImodCoupler, ". => imod_coupler")
         cleanCheckout = true
     }
 
     steps {
-        step {
+        script {
             name = "SonarCloud analysis"
             id = "Sonar_analysis"
-            type = "sonar-plugin"            
-            param("sonarServer", "54d6c253-800e-4025-870b-cb760324147b")
-            param("sonarProjectName", "imod_coupler")
-            param("sonarProjectKey", "Deltares_imod_coupler")
-            param("sonarProjectVersion", "%build.number%")
-
-            param("teamcity.build.workingDir", "imod_coupler")
-            param("sonarProjectSources", "imod_coupler,pre-processing/primod")
-            param("sonarProjectTests", "tests")
-            param("additionalParameters", """
-                    -Dsonar.organization=deltares
-                    -Dsonar.python.version=3.10
-                    -Dsonar.token=%sonar_token%
-                """.trimIndent())
+            workingDir = "imod_coupler"
+            scriptContent = """
+                curl -sSL "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-%sonar_scanner_version%-windows-x64.zip" -o sonar-cli.zip
+                tar -xf sonar-cli.zip
+                sonar-scanner-%sonar_scanner_version%-windows-x64\bin\sonar-scanner.bat "-Dsonar.token=%sonar_token%"
+            """.trimIndent()
         }
     }
 

--- a/.teamcity/_Self/buildTypes/SonarCloud.kt
+++ b/.teamcity/_Self/buildTypes/SonarCloud.kt
@@ -24,6 +24,8 @@ object SonarCloud : BuildType({
             name = "SonarCloud analysis"
             id = "Sonar_analysis"
             type = "sonar-plugin"
+            param("teamcity.build.workingDir", "imod_coupler")
+            param("additionalParameters", "-Dproject.settings=imod_coupler/myproject.properties")
             param("sonarServer", "54d6c253-800e-4025-870b-cb760324147b")
         }
     }

--- a/.teamcity/_Self/buildTypes/SonarCloud.kt
+++ b/.teamcity/_Self/buildTypes/SonarCloud.kt
@@ -3,7 +3,6 @@ package _Self.buildTypes
 import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.*
-import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object SonarCloud : BuildType({
     name = "SonarCloud"
@@ -11,25 +10,29 @@ object SonarCloud : BuildType({
 
     templates(GitHubIntegrationTemplate)
 
-    params {
-        param("sonar_scanner_version", "8.0.1.6346")
-    }
-
     vcs {
         root(ImodCoupler, ". => imod_coupler")
         cleanCheckout = true
     }
 
     steps {
-        script {
+        step {
             name = "SonarCloud analysis"
             id = "Sonar_analysis"
-            workingDir = "imod_coupler"
-            scriptContent = """
-                curl -sSL "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-%sonar_scanner_version%-windows-x64.zip" -o sonar-cli.zip
-                tar -xf sonar-cli.zip
-                sonar-scanner-%sonar_scanner_version%-windows-x64\bin\sonar-scanner.bat "-Dsonar.token=%sonar_token%"
-            """.trimIndent()
+            type = "sonar-plugin"            
+            param("sonarServer", "54d6c253-800e-4025-870b-cb760324147b")
+            param("sonarProjectName", "imod_coupler")
+            param("sonarProjectKey", "Deltares_imod_coupler")
+            param("sonarProjectVersion", "%build.number%")
+
+            param("teamcity.build.workingDir", "imod_coupler")
+            param("sonarProjectSources", "imod_coupler,pre-processing/primod")
+            param("sonarProjectTests", "tests")
+            param("additionalParameters", """
+                    -Dsonar.organization=deltares
+                    -Dsonar.python.version=3.10
+                    -Dsonar.token=%sonar_token%
+                """.trimIndent())
         }
     }
 

--- a/.teamcity/_Self/buildTypes/SonarCloud.kt
+++ b/.teamcity/_Self/buildTypes/SonarCloud.kt
@@ -1,0 +1,35 @@
+package _Self.buildTypes
+
+import Templates.GitHubIntegrationTemplate
+import _Self.vcsRoots.ImodCoupler
+import jetbrains.buildServer.configs.kotlin.*
+
+object SonarCloud : BuildType({
+    name = "SonarCloud"
+    description = "Runs SonarCloud static analysis"
+
+    templates(GitHubIntegrationTemplate)
+
+    params {
+        password("sonar_token", "%sonar_token%")
+    }
+
+    vcs {
+        root(ImodCoupler, ". => imod_coupler")
+        cleanCheckout = true
+    }
+
+    steps {
+        step {
+            name = "SonarCloud analysis"
+            id = "Sonar_analysis"
+            type = "sonar-plugin"
+            param("teamcity.build.workingDir", "imod_coupler")
+            param("sonarServer", "54d6c253-800e-4025-870b-cb760324147b")
+        }
+    }
+
+    requirements {
+        equals("env.OS", "Windows_NT")
+    }
+})

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,0 @@
-sonar.projectKey=Deltares_imod_coupler
-sonar.organization=deltares
-sonar.host.url=https://sonarcloud.io
-
-sonar.sources=imod_coupler,pre-processing/primod
-sonar.tests=tests
-
-sonar.python.version=3.10

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=Deltares_imod_coupler
+sonar.organization=deltares
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=imod_coupler,pre-processing/primod
+sonar.tests=tests
+
+sonar.python.version=3.10

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,3 +6,8 @@ sonar.sources=imod_coupler,pre-processing/primod
 sonar.tests=tests
 
 sonar.python.version=3.10
+
+# We do not have code coverage yet.
+# This excludes all files from coverage calculation
+# so the Quality Gate does not fail.
+sonar.coverage.exclusions=**/*


### PR DESCRIPTION
Fixes #449

This PR reenables sonarqube analysis. A teamcity build step has been added to do so.
The step downloads the sonar-cli and performs the scan. It respects the settings in the sonar-project.properties.