### PR TITLE
Issue #465 Add the github release pipeline

### DIFF
--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -1,7 +1,7 @@
 package Deploy
 
+import IMODCollector.buildTypes.IMODCollector_X64development
 import _Self.vcsRoots.ImodCoupler
-import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
@@ -59,7 +59,7 @@ object CreateGitHubRelease : BuildType({
     }
 
     dependencies {
-        dependency(AbsoluteId("IMODCollector_X64development")) {
+        dependency(IMODCollector_X64development) {
             snapshot {
                 onDependencyFailure = FailureAction.FAIL_TO_START
             }

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -2,6 +2,7 @@ package Deploy
 
 import IMODCollector.buildTypes.IMODCollector_X64development
 import _Self.vcsRoots.ImodCoupler
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
@@ -59,7 +60,7 @@ object CreateGitHubRelease : BuildType({
     }
 
     dependencies {
-        dependency(IMODCollector_X64development) {
+        dependency(AbsoluteId("SigningAndCertificates_IMOD_SigningCollector")) {
             snapshot {
                 onDependencyFailure = FailureAction.FAIL_TO_START
             }

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -1,13 +1,75 @@
 package Deploy
 
 import _Self.vcsRoots.ImodCoupler
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.buildSteps.powerShell
 
 object DeployProject : Project({
     name = "Deploy"
 
+    buildType(CreateGitHubRelease)
+
     buildType(DeployAll)
+})
+
+object CreateGitHubRelease : BuildType({
+    name = "Create GitHub release"
+
+    type = Type.DEPLOYMENT
+    maxRunningBuilds = 1
+
+    params {
+        param("env.GH_TOKEN", "%github_deltares-service-account_access_token%")
+    }
+
+    vcs {
+        root(ImodCoupler)
+
+        cleanCheckout = true
+        branchFilter = """
+            +:*
+            -:<default>
+            -:refs/heads/gh-pages
+        """.trimIndent()
+        showDependenciesChanges = true
+    }
+
+    steps {
+        powerShell {
+            name = "Create GitHub release"
+            id = "Create_GitHub_release"
+            formatStderrAsError = true
+            scriptMode = script {
+                content = """
+                    ${'$'}tag = git describe --tags --abbrev=0 --exact-match
+                    
+                    echo "Creating GitHub release for: ${'$'}tag"
+                    
+                    ${'$'}notesFile = [System.IO.Path]::GetTempFileName()
+                    pixi run --environment default --frozen python scripts/extract_changelog_notes.py ${'$'}tag | Set-Content -Path ${'$'}notesFile -Encoding UTF8
+                    if (${'$'}LASTEXITCODE -ne 0) { exit ${'$'}LASTEXITCODE }
+                    
+                    pixi run --environment default --frozen gh release create ${'$'}tag release/* --verify-tag --notes-file ${'$'}notesFile
+                """.trimIndent()
+            }
+        }
+    }
+
+    dependencies {
+        dependency(AbsoluteId("IMODCollector_X64development")) {
+            snapshot {
+                onDependencyFailure = FailureAction.FAIL_TO_START
+            }
+
+            artifacts {
+                buildRule = lastSuccessful()
+                artifactRules = "+:**/* => release"
+            }
+        }
+    }
 })
 
 object DeployAll : BuildType({
@@ -26,5 +88,10 @@ object DeployAll : BuildType({
             -:refs/heads/gh-pages
         """.trimIndent()
         showDependenciesChanges = true
+    }
+
+    dependencies {
+        snapshot(CreateGitHubRelease) {
+        }
     }
 })

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -50,10 +50,10 @@ object CreateGitHubRelease : BuildType({
                     echo "Creating GitHub release for: ${'$'}tag"
                     
                     ${'$'}notesFile = [System.IO.Path]::GetTempFileName()
-                    pixi run --environment default --frozen python scripts/extract_changelog_notes.py ${'$'}tag | Set-Content -Path ${'$'}notesFile -Encoding UTF8
+                    pixi run --environment dev --frozen python scripts/extract_changelog_notes.py ${'$'}tag | Set-Content -Path ${'$'}notesFile -Encoding UTF8
                     if (${'$'}LASTEXITCODE -ne 0) { exit ${'$'}LASTEXITCODE }
                     
-                    pixi run --environment default --frozen gh release create ${'$'}tag release/* --verify-tag --notes-file ${'$'}notesFile
+                    pixi run --environment dev --frozen gh release create ${'$'}tag release/* --verify-tag --notes-file ${'$'}notesFile
                 """.trimIndent()
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,6 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-## [v2026.4.0-rc.1]
-
-### Added
-
-- A Deploy pipeline has been added to aid in simplifying the coupler release process
-
-### Fixed
-
-### Changed
-
-### Removed
-
 ## [v2025.11.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
+## [v2026.4.0-rc.1]
+
+### Added
+
+- A Deploy pipeline has been added to aid in simpliying the coupler release process
+
+### Fixed
+
+### Changed
+
+### Removed
+
 ## [v2025.11.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,135 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [v2025.11.0]
+
+### Changed
+
+- Update Ribasim to version 2025.6
+- Update MODFLOW6 to version 6.6.3
+- Update iMOD Python to version 1.0.0
+- Primod: Allow grid based basin and water user definitions and facilitate subsetting of subgrid-df
+- Ribasim-MetaSWAP coupling: Pass MetaSWAP timestep to `update_ribasim`
+
+## [v2024.4.0]
+
+### Added
+
+- First imod_coupler release involving a Ribasim-MetaSWAP-MODFLOW6 (RibaMetaMod) implementation
+
+## [v2024.3.0]
+
+### Added
+
+- Add ponding
+- Add formal RibaMetaMod tests
+- Add cron job to update pixi lock file every month
+
+### Fixed
+
+- Additionally check if columns are in data frame
+- Fix primod `RchSvatMapping` layer dimension (#262)
+- Fix name changes of Ribasim variables in `get_value_ptr` statements
+- Deal with potential time axis in conductance
+- Call `add_api_package` to mf6 model
+- Do not overwrite drainage and infiltration values of uncoupled basins
+- Set drainage and infiltration to NA for basins coupled to MODFLOW
+- Call `update_bottom_minimum`
+
+### Changed
+
+- Update numerical scheme for RibaMetaMod
+- Adapt to changes in Ribasim API
+- Move from `requests` to `httpx`
+- Update to pydantic 2.0 validators syntax
+- Move `basin_definition` from RibaMod to DriverCoupling
+- Refactor DriverCoupling
+- Check time of Ribasim and MODFLOW6 model before coupling
+- Improve debugging in Visual Studio Code
+- Auto install test dependencies
+
+## [v2024.01.2]
+
+### Fixed
+
+- Compute budget in a better way; take new fid index into account
+- Fix changes required to get a real coupled model running
+
+### Changed
+
+- Start logging Ribasim version again
+
+## [v2024.01.1]
+
+### Added
+
+- Add pixi task to publish primod
+- Add docs for DriverCoupling
+
+### Changed
+
+- Refactor and activate exchanges for active coupling
+- Use `ribasim-api`: `update_subgrid_level`
+- Add two-basin test models
+
+## [v2024.01.0]
+
+### Added
+
+- Create RibaMetaMod as a copy of RibaMod
+- Add pixi
+- Add MetaMod functionality to RibaMetaMod
+- Add sprinkling exchange MetaSWAP-Ribasim
+- Add temporary RibaMetaMod test
+- Add more ruff rules
+- Optional kernels
+
+### Changed
+
+- Update to newest Ribasim Python API
+- Remove pydantic config `arbitrary_types_allowed`
+- Change memory address for wells and refactor retrieving the pointer
+- Move to hatchling as build backend
+
+## [v2023.08.0]
+
+### Added
+
+- Add initial version of RibaMod
+- Add conversion between time units of Ribasim and MODFLOW6
+- Add minimal conda environment for building the executable
+- Move coupling pre-processing from iMOD Python to primod
+
+### Fixed
+
+- No convergence in MODFLOW6 no longer results in an error
+
+### Changed
+
+- Refactor kernel wrappers
+- Refactor logging
+- Move docs to iMOD Suite Documentation
+- Adapt to newest MODFLOW6 version
+- Remove unnecessary config dir parameter
+
+## [v0.11.0]
+
+### Added
+
+- Moved testbench to pytest, enabling integration and unit tests and making it possible to run tests locally
+
+### Changed
+
+- Moved to new configuration file format
+- Added concept of "drivers"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- A Deploy pipeline has been added to aid in simpliying the coupler release process
+- A Deploy pipeline has been added to aid in simplifying the coupler release process
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -94,3 +94,51 @@ If you encounter errors after pulling the latest changes, your pip dependencies 
 ```sh
 pixi run update-git-dependencies
 ```
+
+### Creating a release
+
+1. Add all notable changes to the `[Unreleased]` section in [CHANGELOG.md](CHANGELOG.md), using the existing subsections (Added, Fixed, Changed, Removed).
+
+2. In CHANGELOG.md, rename `## [Unreleased]` to `## [vYYYY.MM.X] - YYYY-MM-DD` and add a fresh empty `## [Unreleased]` section above it:
+
+   ```markdown
+   ## [Unreleased]
+
+   ### Added
+
+   ### Fixed
+
+   ### Changed
+
+   ### Removed
+
+   ## [vYYYY.MM.X] - YYYY-MM-DD
+   ...
+   ```
+
+   You can verify the notes that will be used for the release with:
+
+   ```sh
+   python scripts/extract_changelog_notes.py vYYYY.MM.X
+   ```
+
+3. Commit the changelog update:
+
+   ```sh
+   git add CHANGELOG.md
+   git commit -m "Release vYYYY.MM.X"
+   ```
+
+4. Tag the commit:
+
+   ```sh
+   git tag vYYYY.MM.X
+   ```
+
+5. Push the commit and tag:
+
+   ```sh
+   git push origin main vYYYY.MM.X
+   ```
+
+6. In TeamCity, select the **Deploy** project and trigger the **Deploy All** build, selecting the tag `vYYYY.MM.X` as the branch. TeamCity will build the artifacts and create the GitHub release using the notes from CHANGELOG.md.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pixi run update-git-dependencies
 
    ### Removed
 
-   ## [vYYYY.MM.X] - YYYY-MM-DD
+   ## [vYYYY.MM.X]
    ...
    ```
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -958,6 +958,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.92.0-hfc2019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.2.0-h3abd4de_0.conda
@@ -1522,6 +1523,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-h6a83c73_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.92.0-h11686cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gl2ps-1.4.2-h26c196c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glew-2.2.0-hcc5dbe9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glslang-16.2.0-h5b34520_0.conda
@@ -1891,7 +1893,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.91.0-hfc2019e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.92.0-hfc2019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
@@ -1941,7 +1943,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.91.0-h11686cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.92.0-h11686cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.5-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
@@ -2120,6 +2122,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.92.0-hfc2019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gl2ps-1.4.2-h36e74d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.2.0-h3abd4de_0.conda
@@ -2683,6 +2686,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-h6a83c73_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.92.0-h11686cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gl2ps-1.4.2-h26c196c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glew-2.2.0-hcc5dbe9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glslang-16.2.0-h5b34520_0.conda
@@ -3211,6 +3215,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.92.0-hfc2019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.47-pyhd8ed1ab_0.conda
@@ -3843,6 +3848,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-h6a83c73_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.92.0-h11686cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.47-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gl2ps-1.4.2-h26c196c_2.conda
@@ -7571,18 +7577,22 @@ packages:
   purls: []
   size: 119654
   timestamp: 1726600001928
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.91.0-hfc2019e_0.conda
-  sha256: 6d541e0951dbbeeb8165d2e9209dc1ede41001bdbc8b7ad1f7464ce242a28c1a
-  md5: 5cf0c191d87ec18a0db448881da5e771
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.92.0-hfc2019e_0.conda
+  sha256: 9e24e0f179505780270a19ffc2c6d88c6ee585240434ec6d4c9c84e864fe80d8
+  md5: e784306b1701fe62450d517096312a4e
   license: Apache-2.0
-  size: 13093885
-  timestamp: 1776894219860
-- conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.91.0-h11686cb_0.conda
-  sha256: 0926c63dc46ba6b3cd16306194387ad45f58d15784589a29eb6cc12c76379319
-  md5: 65d98a9eeb0cad0a8166702a49fb9188
+  license_family: APACHE
+  purls: []
+  size: 13106666
+  timestamp: 1777383228293
+- conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.92.0-h11686cb_0.conda
+  sha256: f704493f01dced8d536aa5a335a79ccef8aa3700c183e7c35d85da9bc2c256c1
+  md5: 4e33e8f0a101e04288a164c5b336551a
   license: Apache-2.0
-  size: 12585846
-  timestamp: 1776894249476
+  license_family: APACHE
+  purls: []
+  size: 12585395
+  timestamp: 1777383265589
 - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
   sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
   md5: 3bf7b9fd5a7136126e0234db4b87c8b6

--- a/pixi.lock
+++ b/pixi.lock
@@ -1893,7 +1893,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.92.0-hfc2019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
@@ -1943,7 +1942,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.92.0-h11686cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.5-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -49,6 +49,7 @@ test-primod = "pytest --junitxml=report.xml tests/test_primod"
 [feature.common.dependencies]
 awscli = "*"
 python-build = "*"
+gh = "*" 
 httpx = "*"
 ipython = "*"
 jupyterlab = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -93,7 +93,6 @@ publish-primod = { cmd = "rm --recursive --force dist && python -m build && twin
 [feature.pixi-update.dependencies]
 pip = "*"
 pixi-diff-to-markdown = "*"
-gh = "*"
 
 [feature.pixi-update.tasks]
 update = "pixi update --json | pixi-diff-to-markdown > diff.md"

--- a/scripts/extract_changelog_notes.py
+++ b/scripts/extract_changelog_notes.py
@@ -1,0 +1,46 @@
+"""
+Extract the release notes for a given version tag from CHANGELOG.md.
+
+Prints the notes to stdout so they can be captured by a calling script.
+
+Usage:
+    python scripts/extract_changelog_notes.py <version>
+
+Example:
+    python scripts/extract_changelog_notes.py v1.2.0
+"""
+
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG = Path(__file__).parent.parent / "CHANGELOG.md"
+
+
+def extract_notes(text: str, version: str) -> str:
+    escaped = re.escape(version)
+    pattern = re.compile(
+        rf"## \[{escaped}\][^\n]*\n(.*?)(?=\n## |\Z)", re.DOTALL
+    )
+    match = pattern.search(text)
+    if not match:
+        raise SystemExit(
+            f"Could not find a section for [{version}] in CHANGELOG.md"
+        )
+    notes = match.group(1).strip()
+    if not notes:
+        raise SystemExit(f"The [{version}] section in CHANGELOG.md is empty")
+    return notes
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(f"Usage: python {sys.argv[0]} <version>  (e.g. v1.2.0)")
+
+    version = sys.argv[1]
+    text = CHANGELOG.read_text(encoding="utf-8")
+    print(extract_notes(text, version))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_changelog_notes.py
+++ b/scripts/extract_changelog_notes.py
@@ -19,14 +19,10 @@ CHANGELOG = Path(__file__).parent.parent / "CHANGELOG.md"
 
 def extract_notes(text: str, version: str) -> str:
     escaped = re.escape(version)
-    pattern = re.compile(
-        rf"## \[{escaped}\][^\n]*\n(.*?)(?=\n## |\Z)", re.DOTALL
-    )
+    pattern = re.compile(rf"## \[{escaped}\][^\n]*\n(.*?)(?=\n## |\Z)", re.DOTALL)
     match = pattern.search(text)
     if not match:
-        raise SystemExit(
-            f"Could not find a section for [{version}] in CHANGELOG.md"
-        )
+        raise SystemExit(f"Could not find a section for [{version}] in CHANGELOG.md")
     notes = match.group(1).strip()
     if not notes:
         raise SystemExit(f"The [{version}] section in CHANGELOG.md is empty")

--- a/scripts/extract_changelog_notes.py
+++ b/scripts/extract_changelog_notes.py
@@ -7,7 +7,7 @@ Usage:
     python scripts/extract_changelog_notes.py <version>
 
 Example:
-    python scripts/extract_changelog_notes.py v1.2.0
+    python scripts/extract_changelog_notes.py v2025.11.0
 """
 
 import re


### PR DESCRIPTION
In this PR a github release pipeline is added to the deploy pipeline.

It creates a new release on Github and adds the sources and collector.zip to it.
The imodc.exe in the released is signed.
It extracts the release notes from the changelog.md file and adds it to the release description

The readme.me had been extended with instructions on how to create a release