### PR TITLE
Issue #463 Create pipeline for deploying Primod to PyPi

### DIFF
--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -1,13 +1,54 @@
 package Deploy
 
 import _Self.vcsRoots.ImodCoupler
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object DeployProject : Project({
     name = "Deploy"
 
+    buildType(BuildPrimodPackage)
+
     buildType(DeployAll)
+})
+
+object BuildPrimodPackage : BuildType({
+    name = "Build Primod package"
+
+    artifactRules = """imod_coupler\pre-processing\dist => dist.zip"""
+
+    vcs {
+        root(ImodCoupler, ". => imod_coupler")
+
+        cleanCheckout = true
+        branchFilter = """
+            +:*
+            -:<default>
+            -:refs/heads/gh-pages
+        """.trimIndent()
+        showDependenciesChanges = true
+    }
+
+    steps {
+        script {
+            name = "Create Primod package"
+            id = "Create_Primod_package"
+            workingDir = "imod_coupler"
+            scriptContent = """
+                SET TEMP=%system.teamcity.build.checkoutDir%\tmpdir
+                SET TMPDIR=%system.teamcity.build.checkoutDir%\tmpdir
+                SET TMP=%system.teamcity.build.checkoutDir%\tmpdir
+
+                pixi run --environment dev --frozen build-primod
+            """.trimIndent()
+            formatStderrAsError = true
+        }
+    }
+
 })
 
 object DeployAll : BuildType({
@@ -26,5 +67,10 @@ object DeployAll : BuildType({
             -:refs/heads/gh-pages
         """.trimIndent()
         showDependenciesChanges = true
+    }
+
+    dependencies {
+        snapshot(BuildPrimodPackage) {
+        }
     }
 })

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -49,6 +49,10 @@ object BuildPrimodPackage : BuildType({
         }
     }
 
+    requirements {
+        equals("env.OS", "Windows_NT")
+    }
+
 })
 
 object DeployAll : BuildType({

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -39,10 +39,6 @@ object BuildPrimodPackage : BuildType({
             id = "Create_Primod_package"
             workingDir = "imod_coupler"
             scriptContent = """
-                SET TEMP=%system.teamcity.build.checkoutDir%\tmpdir
-                SET TMPDIR=%system.teamcity.build.checkoutDir%\tmpdir
-                SET TMP=%system.teamcity.build.checkoutDir%\tmpdir
-
                 pixi run --environment dev --frozen build-primod
             """.trimIndent()
             formatStderrAsError = true

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -96,6 +96,10 @@ object DeployPrimodPackage : BuildType({
             }
         }
     }
+
+    requirements {
+        equals("env.OS", "Windows_NT")
+    }
 })
 
 object DeployAll : BuildType({

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -3,6 +3,7 @@ package Deploy
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
@@ -12,6 +13,7 @@ object DeployProject : Project({
     name = "Deploy"
 
     buildType(BuildPrimodPackage)
+    buildType(DeployPrimodPackage)
 
     buildType(DeployAll)
 })
@@ -51,6 +53,51 @@ object BuildPrimodPackage : BuildType({
 
 })
 
+object DeployPrimodPackage : BuildType({
+     name = "Deploy Primod Package"
+
+    params {
+        param("env.TWINE_USERNAME", "__token__")
+        param("env.TWINE_NON_INTERACTIVE", "true")
+        password("env.TWINE_PASSWORD", "credentialsJSON:2cea585c-e4f8-4a45-9941-9189daf09ecc")
+    }
+
+    vcs {
+        root(ImodCoupler, ". => imod_coupler")
+
+        cleanCheckout = true
+        branchFilter = """
+            +:*
+            -:<default>
+            -:refs/heads/gh-pages
+        """.trimIndent()
+        showDependenciesChanges = true
+    }
+
+    steps {
+        script {
+            name = "Deploy Primod to PyPi"
+            id = "Deploy_Primod_to_PyPi"
+            workingDir = "imod_coupler"
+            scriptContent = """
+                pixi run --environment dev --frozen publish-primod
+            """.trimIndent()
+        }
+    }
+
+    dependencies {
+        dependency(BuildPrimodPackage) {
+            snapshot {
+                onDependencyFailure = FailureAction.FAIL_TO_START
+            }
+
+            artifacts {
+                artifactRules = """+:dist.zip!** => imod_coupler\pre-processing\dist"""
+            }
+        }
+    }
+})
+
 object DeployAll : BuildType({
     name = "Deploy All"
 
@@ -70,7 +117,7 @@ object DeployAll : BuildType({
     }
 
     dependencies {
-        snapshot(BuildPrimodPackage) {
+        snapshot(DeployPrimodPackage) {
         }
     }
 })

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -59,7 +59,7 @@ object DeployPrimodPackage : BuildType({
     params {
         param("env.TWINE_USERNAME", "__token__")
         param("env.TWINE_NON_INTERACTIVE", "true")
-        password("env.TWINE_PASSWORD", "credentialsJSON:2cea585c-e4f8-4a45-9941-9189daf09ecc")
+        password("env.TWINE_PASSWORD", "credentialsJSON:5b785916-d498-4c7f-9dca-e841152a761c")
     }
 
     vcs {

--- a/README.md
+++ b/README.md
@@ -94,3 +94,17 @@ If you encounter errors after pulling the latest changes, your pip dependencies 
 ```sh
 pixi run update-git-dependencies
 ```
+
+### Releasing primod
+
+The `primod` package is published to [PyPI](https://pypi.org/project/primod/). To release a new version:
+
+1. Update the version number in `pre-processing/primod/__init__.py`.
+
+2. Build and publish:
+
+   ```sh
+   pixi run -e dev publish-primod
+   ```
+
+   This will build the package (if sources have changed) and upload it to PyPI via `twine`.

--- a/pixi.toml
+++ b/pixi.toml
@@ -88,7 +88,7 @@ check-package-primod = { cmd = "rm --recursive --force dist && python -m build &
 lint = { depends-on = ["format", "ruff", "mypy-imodc", "mypy-primod"] }
 # Build & publish primod
 build-primod = { cmd = "rm --recursive --force dist && python -m build && twine check dist/*", cwd = "pre-processing", inputs = ["pre-processing/primod/**", "pre-processing/pyproject.toml"] }
-publish-primod = { cmd = "twine upload dist/*", cwd = "pre-processing", depends-on = ["build-primod"] }
+publish-primod = { cmd = "twine upload dist/*", cwd = "pre-processing"}
 
 [feature.pixi-update.dependencies]
 pip = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -86,8 +86,9 @@ format-check = "ruff format --check ."
 ruff = "ruff check ."
 check-package-primod = { cmd = "rm --recursive --force dist && python -m build && twine check --strict dist/*", cwd = "pre-processing" }
 lint = { depends-on = ["format", "ruff", "mypy-imodc", "mypy-primod"] }
-# Publish primod
-publish-primod = { cmd = "rm --recursive --force dist && python -m build && twine check dist/* && twine upload dist/*", cwd = "pre-processing" }
+# Build & publish primod
+build-primod = { cmd = "rm --recursive --force dist && python -m build && twine check dist/*", cwd = "pre-processing", inputs = ["pre-processing/primod/**", "pre-processing/pyproject.toml"] }
+publish-primod = { cmd = "twine upload dist/*", cwd = "pre-processing", depends-on = ["build-primod"] }
 
 [feature.pixi-update.dependencies]
 pip = "*"


### PR DESCRIPTION
This PR extends to Deploy pipeline with the deployment of Primod to PiPy.
The deploy phase is divided in 2 steps
1 build the package
2 deploy the package

This makes it easier to debug the pipeline because we can test the build step without deploying.
An added benefit is that the package is accesible as an artifact

Furthermore i updated the release steps in de README file