### PR TITLE
Issue #464 Create pipeline for deploying Coupler to PyPi 

### DIFF
--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -1,13 +1,11 @@
 package Deploy
 
-import IMODCollector.buildTypes.IMODCollector_X64development
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.buildSteps.powerShell
-import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object DeployProject : Project({
@@ -15,6 +13,8 @@ object DeployProject : Project({
 
     buildType(BuildPrimodPackage)
     buildType(DeployPrimodPackage)
+    buildType(BuildCouplerPackage)
+    buildType(DeployCouplerPackage)
     buildType(CreateGitHubRelease)
 
 
@@ -105,6 +105,90 @@ object DeployPrimodPackage : BuildType({
     }
 })
 
+object BuildCouplerPackage : BuildType({
+    name = "Build Coupler package"
+
+    artifactRules = """imod_coupler\dist => dist.zip"""
+
+    vcs {
+        root(ImodCoupler, ". => imod_coupler")
+
+        cleanCheckout = true
+        branchFilter = """
+            +:*
+            -:<default>
+            -:refs/heads/gh-pages
+        """.trimIndent()
+        showDependenciesChanges = true
+    }
+
+    steps {
+        script {
+            name = "Create Coupler package"
+            id = "Create_Coupler_package"
+            workingDir = "imod_coupler"
+            scriptContent = """
+                pixi run --environment dev --frozen build-coupler
+            """.trimIndent()
+            formatStderrAsError = true
+        }
+    }
+
+    requirements {
+        equals("env.OS", "Windows_NT")
+    }
+
+})
+
+object DeployCouplerPackage : BuildType({
+    name = "Deploy Coupler Package"
+
+    params {
+        param("env.TWINE_USERNAME", "__token__")
+        param("env.TWINE_NON_INTERACTIVE", "true")
+        //password("env.TWINE_PASSWORD", "credentialsJSON:5b785916-d498-4c7f-9dca-e841152a761c")
+    }
+
+    vcs {
+        root(ImodCoupler, ". => imod_coupler")
+
+        cleanCheckout = true
+        branchFilter = """
+            +:*
+            -:<default>
+            -:refs/heads/gh-pages
+        """.trimIndent()
+        showDependenciesChanges = true
+    }
+
+    steps {
+        script {
+            name = "Deploy Coupler to PyPi"
+            id = "Deploy_Coupler_to_PyPi"
+            workingDir = "imod_coupler"
+            scriptContent = """
+                pixi run --environment dev --frozen publish-coupler
+            """.trimIndent()
+        }
+    }
+
+    dependencies {
+        dependency(BuildCouplerPackage) {
+            snapshot {
+                onDependencyFailure = FailureAction.FAIL_TO_START
+            }
+
+            artifacts {
+                artifactRules = """+:dist.zip!** => imod_coupler\dist"""
+            }
+        }
+    }
+
+    requirements {
+        equals("env.OS", "Windows_NT")
+    }
+})
+
 object CreateGitHubRelease : BuildType({
     name = "Create GitHub release"
 
@@ -182,6 +266,8 @@ object DeployAll : BuildType({
 
     dependencies {
         snapshot(DeployPrimodPackage) {
+        }
+        snapshot(DeployCouplerPackage) {
         }
        snapshot(CreateGitHubRelease) {
         }

--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -31,9 +31,7 @@ object BuildPrimodPackage : BuildType({
 
         cleanCheckout = true
         branchFilter = """
-            +:*
-            -:<default>
-            -:refs/heads/gh-pages
+            +:refs/tags/*
         """.trimIndent()
         showDependenciesChanges = true
     }
@@ -70,9 +68,7 @@ object DeployPrimodPackage : BuildType({
 
         cleanCheckout = true
         branchFilter = """
-            +:*
-            -:<default>
-            -:refs/heads/gh-pages
+            +:refs/tags/*
         """.trimIndent()
         showDependenciesChanges = true
     }
@@ -115,9 +111,7 @@ object BuildCouplerPackage : BuildType({
 
         cleanCheckout = true
         branchFilter = """
-            +:*
-            -:<default>
-            -:refs/heads/gh-pages
+            +:refs/tags/*
         """.trimIndent()
         showDependenciesChanges = true
     }
@@ -146,7 +140,7 @@ object DeployCouplerPackage : BuildType({
     params {
         param("env.TWINE_USERNAME", "__token__")
         param("env.TWINE_NON_INTERACTIVE", "true")
-        //password("env.TWINE_PASSWORD", "credentialsJSON:5b785916-d498-4c7f-9dca-e841152a761c")
+        password("env.TWINE_PASSWORD", "credentialsJSON:7b90c3fe-f8f9-4e97-8847-d5fc5495760c")
     }
 
     vcs {
@@ -154,9 +148,7 @@ object DeployCouplerPackage : BuildType({
 
         cleanCheckout = true
         branchFilter = """
-            +:*
-            -:<default>
-            -:refs/heads/gh-pages
+            +:refs/tags/*
         """.trimIndent()
         showDependenciesChanges = true
     }
@@ -204,9 +196,7 @@ object CreateGitHubRelease : BuildType({
 
         cleanCheckout = true
         branchFilter = """
-            +:*
-            -:<default>
-            -:refs/heads/gh-pages
+            +:refs/tags/*
         """.trimIndent()
         showDependenciesChanges = true
     }
@@ -257,9 +247,7 @@ object DeployAll : BuildType({
 
         cleanCheckout = true
         branchFilter = """
-            +:*
-            -:<default>
-            -:refs/heads/gh-pages
+            +:refs/tags/*
         """.trimIndent()
         showDependenciesChanges = true
     }

--- a/README.md
+++ b/README.md
@@ -97,11 +97,13 @@ pixi run update-git-dependencies
 
 ### Creating a release
 
-1. Update the version number in `pre-processing/primod/__init__.py`.
+1. Update the version number in `imod-coupler/__init__.py`.
 
-2. Add all notable changes to the `[Unreleased]` section in [CHANGELOG.md](CHANGELOG.md), using the existing subsections (Added, Fixed, Changed, Removed).
+2. Update the version number in `pre-processing/primod/__init__.py`.
 
-3. In CHANGELOG.md, rename `## [Unreleased]` to `## [vYYYY.MM.X] - YYYY-MM-DD` and add a fresh empty `## [Unreleased]` section above it:
+3. Add all notable changes to the `[Unreleased]` section in [CHANGELOG.md](CHANGELOG.md), using the existing subsections (Added, Fixed, Changed, Removed).
+
+4. In CHANGELOG.md, rename `## [Unreleased]` to `## [vYYYY.MM.X] - YYYY-MM-DD` and add a fresh empty `## [Unreleased]` section above it:
 
    ```markdown
    ## [Unreleased]
@@ -124,23 +126,23 @@ pixi run update-git-dependencies
    python scripts/extract_changelog_notes.py vYYYY.MM.X
    ```
 
-4. Commit the changelog and the init file updates:
+5. Commit the changelog and the init file updates:
 
    ```sh
    git add CHANGELOG.md pre-processing/primod/__init__.py
    git commit -m "Release vYYYY.MM.X"
    ```
 
-5. Push the commit and tag:
-
-   ```sh
-   git push origin main vYYYY.MM.X
-   ```
-
-6. When the commit has been merged to main, checkout main and tag the commit:
+6. When the commit has been merged to main or a release branch, switch to that branch and tag the commit:
 
    ```sh
    git tag vYYYY.MM.X
    ```
 
-7. In TeamCity, select the **Deploy** project and trigger the **Deploy All** build, selecting the tag `vYYYY.MM.X` as the branch. TeamCity will build the artifacts and create the GitHub release using the notes from CHANGELOG.md.
+7. Push the tag:
+
+   ```sh
+   git push origin vYYYY.MM.X
+   ```
+
+8. In TeamCity, select the **Deploy** project and trigger the **Deploy All** build, selecting the tag `vYYYY.MM.X` as the branch. TeamCity will build the artifacts and create the GitHub release using the notes from CHANGELOG.md.

--- a/pixi.lock
+++ b/pixi.lock
@@ -8265,7 +8265,7 @@ packages:
 - pypi: ./
   name: imod-coupler
   version: 2024.3.0
-  sha256: 6122af2d8f5c2defef6e4ff958533e3df6c49a48d1801b2cdc70438e62a2c1d5
+  sha256: c8179a32e63cc3af7c2300c4acd7a87e5816139a6f4598e05e7fc1f6d29f942e
   requires_dist:
   - h5netcdf
   - loguru

--- a/pixi.toml
+++ b/pixi.toml
@@ -90,6 +90,9 @@ lint = { depends-on = ["format", "ruff", "mypy-imodc", "mypy-primod"] }
 # Build & publish primod
 build-primod = { cmd = "rm --recursive --force dist && python -m build && twine check dist/*", cwd = "pre-processing", inputs = ["pre-processing/primod/**", "pre-processing/pyproject.toml"] }
 publish-primod = { cmd = "twine upload dist/*", cwd = "pre-processing"}
+# Build & publish coupler
+build-coupler = { cmd = "rm --recursive --force dist && python -m build && twine check dist/*", inputs = ["imod_coupler/**", "pyproject.toml"] }
+publish-coupler = { cmd = "twine upload dist/*", cwd = "." }
 
 [feature.pixi-update.dependencies]
 pip = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[tool.hatch.build.targets.sdist]
+include = ["imod_coupler/", "README.md", "pyproject.toml"]
+
 [tool.hatch.version]
 path = "imod_coupler/__init__.py"
 


### PR DESCRIPTION
This PR adds a deploy pipeline for the coupler in a similair fashion as the one for Primod #463

There wasn't a pixi task to facilitate in this process so that has been added.
The Readme is updated with the additional steps needed

The branch filter has been updated to restrict the deploy pipeline to tagged commits only