### PR TITLE
Issue #743 Fix failing pixi update ci due to missing gh tool

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1893,6 +1893,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.92.0-hfc2019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
@@ -1942,6 +1943,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.92.0-h11686cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.5-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -96,6 +96,7 @@ build-coupler = { cmd = "rm --recursive --force dist && python -m build && twine
 publish-coupler = { cmd = "twine upload dist/*", cwd = "." }
 
 [feature.pixi-update.dependencies]
+gh = "*"
 pip = "*"
 pixi-diff-to-markdown = "*"
 


### PR DESCRIPTION
This PR fixes the failing pixi update pipeline.
It was failing because it is missing the `gh` tool needed to create a PR on github.
This PR adds that dependency to the `pixi-update.dependencies` environment