### PR TITLE
Fix silent crash when the run_coupler encountered an exception

### DIFF
--- a/tests/fixtures/fixture_run_coupler_function.py
+++ b/tests/fixtures/fixture_run_coupler_function.py
@@ -1,9 +1,9 @@
-import multiprocessing
 import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
 
+import concurrent
 import pytest
 
 from imod_coupler.__main__ import run_coupler
@@ -26,11 +26,15 @@ def run_coupler_function(imod_coupler_exec_devel: Path) -> Callable[[Path], None
         def run_coupler_debug(file: Path) -> None:
             # Start the coupler in a separate process. This avoids dll unloading issues
             # when the dll crashes.
-            p = multiprocessing.Process(target=_run_coupler_worker, args=(file,))
-            p.start()
-            p.join()
-            if p.exitcode != 0:
-                raise subprocess.CalledProcessError(p.exitcode, "run_coupler")
+            executor = concurrent.futures.ProcessPoolExecutor(max_workers=1)
+            try:
+                future = executor.submit(_run_coupler_worker, file)
+                future.result()
+            except Exception as e:
+                raise subprocess.CalledProcessError(returncode=1, cmd=[str(run_coupler), str(file)], output=None, stderr=e.args[0])
+            finally:
+                executor.shutdown(wait=False)
+
 
         return run_coupler_debug
     else:

--- a/tests/fixtures/fixture_run_coupler_function.py
+++ b/tests/fixtures/fixture_run_coupler_function.py
@@ -31,10 +31,14 @@ def run_coupler_function(imod_coupler_exec_devel: Path) -> Callable[[Path], None
                 future = executor.submit(_run_coupler_worker, file)
                 future.result()
             except Exception as e:
-                raise subprocess.CalledProcessError(returncode=1, cmd=[str(run_coupler), str(file)], output=None, stderr=e.args[0])
+                raise subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd=[str(run_coupler), str(file)],
+                    output=None,
+                    stderr=e.args[0],
+                )
             finally:
                 executor.shutdown(wait=False)
-
 
         return run_coupler_debug
     else:

--- a/tests/fixtures/fixture_run_coupler_function.py
+++ b/tests/fixtures/fixture_run_coupler_function.py
@@ -1,9 +1,9 @@
+import concurrent
 import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
 
-import concurrent
 import pytest
 
 from imod_coupler.__main__ import run_coupler


### PR DESCRIPTION
The exception raised when a dll crashed was silently ignored when calling it though the run_coupler_debug method.

This PR fixes that. The ProcessPoolExecutor automatically handles exception unlike multiprocessing.Process.
The exception is then rethrown as a CalledProcessError exception to be in line with the exception that would be raised when it was run through the imodc.exe