### PR TITLE
Ensure that the Pixi pipeline fails when one of its substeps fail

### DIFF
--- a/.teamcity/Pixi/PixiProject.kt
+++ b/.teamcity/Pixi/PixiProject.kt
@@ -3,6 +3,7 @@ package Pixi
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.buildSteps.PowerShellStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.triggers.schedule
 
@@ -29,9 +30,14 @@ object UpdateDependencies : BuildType({
         powerShell {
             name = "Update dependencies"
             id = "Update_dependencies"
+            edition = PowerShellStep.Edition.Core
             workingDir = "imod_coupler"
             scriptMode = script {
                 content = """
+                    # Fail the build when any command returns a non-zero exit code.
+                    ${'$'}ErrorActionPreference = "Stop"
+                    ${'$'}PSNativeCommandUseErrorActionPreference = ${'$'}true
+
                     echo "Create update branch"
                     git remote set-url origin https://%GH_USER%:%env.GH_TOKEN%@github.com/Deltares/imod_coupler.git
                     git checkout -b pixi_update_%build.counter%


### PR DESCRIPTION
The pixi pipeline failed however on TeamCity it is still marked as succeeded.
This is because the powershell version in which the pipeline is run doesn't handle errors correctly.

In this PR the powershell version being used is changed to  7.3 Core. This version has some build in error handling settings that we can use. In particular:
- PSNativeCommandUseErrorActionPreference: This is used to capture the error code of the commands being called in the script e.g. "pixi run -e pixi-update update"
- ErrorActionPreference: This determines the action after an error occured

After these changes the build should fail "correctly"