### PR TITLE
Run lint pipeline in docker container

### DIFF
--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -51,7 +51,7 @@ object BuildPrimodPackage : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 
 })
@@ -101,7 +101,7 @@ object DeployPrimodPackage : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })
 
@@ -135,7 +135,7 @@ object BuildCouplerPackage : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 
 })
@@ -185,7 +185,7 @@ object DeployCouplerPackage : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })
 

--- a/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
+++ b/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
@@ -76,6 +76,6 @@ object IMODCollector_X64development : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })

--- a/.teamcity/Weekly/WeeklyProject.kt
+++ b/.teamcity/Weekly/WeeklyProject.kt
@@ -107,7 +107,7 @@ object AcceptanceTests : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })
 

--- a/.teamcity/_Self/Project.kt
+++ b/.teamcity/_Self/Project.kt
@@ -18,6 +18,11 @@ import jetbrains.buildServer.configs.kotlin.projectFeatures.dockerRegistry
 object Project : Project({
     description = "Python scripts coupling components"
 
+    params {
+        param("DockerContainer", "containers.deltares.nl/hydrology_product_line_imod/windows-pixi")
+        param("DockerVersion", "v0.69.0")
+    }
+
     vcsRoot(MetaSwapLookupTable)
     vcsRoot(ImodCoupler)
 

--- a/.teamcity/_Self/buildTypes/Lint.kt
+++ b/.teamcity/_Self/buildTypes/Lint.kt
@@ -23,6 +23,7 @@ object Lint : BuildType({
             id = "Run_ruff_format_check"
             workingDir = "imod_coupler"
             scriptContent = """
+                    pixi config set --local detached-environments "C:\pixi_envs"
                     pixi run --environment dev --frozen format-check 
                 """.trimIndent()
             formatStderrAsError = true
@@ -36,6 +37,7 @@ object Lint : BuildType({
             id = "Run_ruff"
             workingDir = "imod_coupler"
             scriptContent = """
+                    pixi config set --local detached-environments "C:\pixi_envs"
                     pixi run --environment dev --frozen ruff
                 """.trimIndent()
             formatStderrAsError = true

--- a/.teamcity/_Self/buildTypes/Lint.kt
+++ b/.teamcity/_Self/buildTypes/Lint.kt
@@ -3,6 +3,8 @@ package _Self.buildTypes
 import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object Lint : BuildType({
@@ -24,6 +26,10 @@ object Lint : BuildType({
                     pixi run --environment dev --frozen format-check 
                 """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
         script {
             name = "Run ruff"
@@ -33,10 +39,18 @@ object Lint : BuildType({
                     pixi run --environment dev --frozen ruff
                 """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
     }
 
-    requirements {
-        equals("env.OS", "Windows_NT")
+    features {
+        dockerRegistryConnections {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_342"
+            }
+        }
     }
 })

--- a/.teamcity/_Self/buildTypes/MyPy.kt
+++ b/.teamcity/_Self/buildTypes/MyPy.kt
@@ -62,6 +62,6 @@ object MyPy : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })

--- a/.teamcity/_Self/buildTypes/SonarCloud.kt
+++ b/.teamcity/_Self/buildTypes/SonarCloud.kt
@@ -34,6 +34,6 @@ object SonarCloud : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })

--- a/.teamcity/_Self/buildTypes/TestPrimodWin64.kt
+++ b/.teamcity/_Self/buildTypes/TestPrimodWin64.kt
@@ -82,6 +82,6 @@ object TestPrimodWin64 : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })

--- a/.teamcity/_Self/buildTypes/TestbenchCouplerWin64.kt
+++ b/.teamcity/_Self/buildTypes/TestbenchCouplerWin64.kt
@@ -114,6 +114,6 @@ object TestbenchCouplerWin64 : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })

--- a/.teamcity/_Self/buildTypes/TwineCheck.kt
+++ b/.teamcity/_Self/buildTypes/TwineCheck.kt
@@ -28,6 +28,6 @@ object TwineCheck : BuildType({
     }
 
     requirements {
-        equals("env.OS", "Windows_NT")
+        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })


### PR DESCRIPTION
In this PR the lint pipeline has been updated to run its build steps inside a docker container.
This gives us more control over the available packages and provides us with a way to debug a failing TeamCity build locally.

The scope has been limited to the lint pipeline to test the container workflow

The docker builds need to run a different agent pool then the non-docker builds.
The docker feature automatically set an agent requirment and picks the right agent.
For the non-docker builds i changed the os requirment to Windows 11. These agents contains required tools like pixi