### PR TITLE
Fix failing pixi update pipeline

### DIFF
--- a/.teamcity/Pixi/PixiProject.kt
+++ b/.teamcity/Pixi/PixiProject.kt
@@ -39,6 +39,9 @@ object UpdateDependencies : BuildType({
                     ${'$'}ErrorActionPreference = "Stop"
                     ${'$'}PSNativeCommandUseErrorActionPreference = ${'$'}true
 
+                    echo "Set environment location for detached environments" 
+                    pixi config set --local detached-environments "C:\pixi_envs"
+
                     echo "Create update branch"
                     git remote set-url origin https://%GH_USER%:%env.GH_TOKEN%@github.com/Deltares/imod_coupler.git
                     git checkout -b pixi_update_%build.counter%


### PR DESCRIPTION
The pixi update pipeline fails with the error:
 Pixi task (update in pixi-update): pixi update --json | pixi-diff-to-markdown > diff.md
```
10:53:23   Error:   × failed to link pygments-2.20.0-pyhd8ed1ab_0.conda
10:53:23     ├─▶ failed to link 'site-packages/pygments/styles/nord.py'
10:53:23     ├─▶ could not update file modification and access time
10:53:23     ╰─▶ The process cannot access the file because it is being used by another
10:53:23         process. (os error 32)
```

This is caused because the host system access the files at the same time as the docker container.
To precent this the pixi environment location is moved outside of the mounted volume to a location exclusively available to the container itself