### PR TITLE
Convert the remaining components of the main pipeline to docker builds

### DIFF
--- a/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
+++ b/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
@@ -6,7 +6,9 @@ import _Self.buildTypes.MyPy
 import _Self.buildTypes.TwineCheck
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
 import jetbrains.buildServer.configs.kotlin.FailureAction
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object IMODCollector_X64development : BuildType({
@@ -36,28 +38,24 @@ object IMODCollector_X64development : BuildType({
             workingDir = "coupler"
             scriptContent = """
                 pixi --version
+                pixi config set --local detached-environments "C:\pixi_envs"
                 pixi install -e dev
                 pixi list
-            """.trimIndent()
-        }
-        script {
-            name = "Get coupler dependencies"
-            workingDir = "coupler"
-            scriptContent = """
+                
+                echo "Get coupler dependencies"
                 pixi run -e dev fetch-imod-collector
-            """.trimIndent()
-        }
-        script {
-            name = "Create executable with pyinstaller"
-            workingDir = "coupler"
-            scriptContent = """
+                
+                echo "Create executable with pyinstaller"
                 pixi run -e dev build-imod-coupler
+                
+                echo "Get version from imod coupler"
+                call dist\imodc --version
             """.trimIndent()
-        }
-        script {
-            name = "Get version from imod coupler"
-            workingDir = "coupler"
-            scriptContent = """call dist\imodc --version"""
+            formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
     }
 
@@ -75,7 +73,11 @@ object IMODCollector_X64development : BuildType({
         }
     }
 
-    requirements {
-        equals("teamcity.agent.jvm.os.name", "Windows 11")
+    features {
+        dockerRegistryConnections {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_342"
+            }
+        }
     }
 })

--- a/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
+++ b/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
@@ -37,9 +37,10 @@ object IMODCollector_X64development : BuildType({
             name = "Set up pixi"
             workingDir = "coupler"
             scriptContent = """
-                echo "Correct temp folders"
-                rem Use the temp directory inside the container instead of
-                rem the host system one
+                echo "Configure temporary directories for Docker container"
+                rem Override TEMP and TMP to use container's temp directory
+                rem instead of the host system's temp directory to prevent
+                rem the host system from locking the files
                 set TEMP=C:\Windows\TEMP
                 set TMP=C:\Windows\TEMP
                 

--- a/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
+++ b/.teamcity/IMODCollector/buildTypes/IMODCollector_X64development.kt
@@ -37,6 +37,12 @@ object IMODCollector_X64development : BuildType({
             name = "Set up pixi"
             workingDir = "coupler"
             scriptContent = """
+                echo "Correct temp folders"
+                rem Use the temp directory inside the container instead of
+                rem the host system one
+                set TEMP=C:\Windows\TEMP
+                set TMP=C:\Windows\TEMP
+                
                 pixi --version
                 pixi config set --local detached-environments "C:\pixi_envs"
                 pixi install -e dev

--- a/.teamcity/_Self/buildTypes/MyPy.kt
+++ b/.teamcity/_Self/buildTypes/MyPy.kt
@@ -3,9 +3,11 @@ package _Self.buildTypes
 import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
 import jetbrains.buildServer.configs.kotlin.buildFeatures.XmlReport
 import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.failureConditions.failOnMetricChange
 
@@ -25,20 +27,30 @@ object MyPy : BuildType({
             id = "Run_mypy_on_imodc"
             workingDir = "imod_coupler"
             scriptContent = """
+                    pixi config set --local detached-environments "C:\pixi_envs"
                     pixi run --environment dev --frozen mypy-imodc-report
                     pixi run --environment dev --frozen mypy-imodc
                 """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
         script {
             name = "Run mypy on primod"
             id = "Run_mypy_on_primod"
             workingDir = "imod_coupler"
             scriptContent = """
+                    pixi config set --local detached-environments "C:\pixi_envs"
                     pixi run --environment dev --frozen mypy-primod-report
                     pixi run --environment dev --frozen mypy-primod
                 """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
     }
 
@@ -59,9 +71,10 @@ object MyPy : BuildType({
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod_coupler/*.xml"
         }
-    }
-
-    requirements {
-        equals("teamcity.agent.jvm.os.name", "Windows 11")
+        dockerRegistryConnections {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_342"
+            }
+        }
     }
 })

--- a/.teamcity/_Self/buildTypes/SonarCloud.kt
+++ b/.teamcity/_Self/buildTypes/SonarCloud.kt
@@ -3,6 +3,8 @@ package _Self.buildTypes
 import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object SonarCloud : BuildType({
@@ -30,10 +32,19 @@ object SonarCloud : BuildType({
                 tar -xf sonar-cli.zip
                 sonar-scanner-%sonar_scanner_version%-windows-x64\bin\sonar-scanner.bat "-Dsonar.token=%sonar_token%"
             """.trimIndent()
+            formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
     }
 
-    requirements {
-        equals("teamcity.agent.jvm.os.name", "Windows 11")
+    features {
+        dockerRegistryConnections {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_342"
+            }
+        }
     }
 })

--- a/.teamcity/_Self/buildTypes/TestPrimodWin64.kt
+++ b/.teamcity/_Self/buildTypes/TestPrimodWin64.kt
@@ -5,10 +5,12 @@ import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import _Self.vcsRoots.MetaSwapLookupTable
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.PublishMode
 import jetbrains.buildServer.configs.kotlin.buildFeatures.XmlReport
 import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object TestPrimodWin64 : BuildType({
@@ -53,7 +55,15 @@ object TestPrimodWin64 : BuildType({
             name = "Run tests"
             id = "RUNNER_1503"
             workingDir = "imod_coupler"
-            scriptContent = "pixi run --environment %pixi-environment% test-primod"
+            scriptContent = """
+                    pixi config set --local detached-environments "C:\pixi_envs"
+                    pixi run --environment %pixi-environment% test-primod
+                """.trimIndent()
+            formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
     }
 
@@ -63,6 +73,11 @@ object TestPrimodWin64 : BuildType({
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod_coupler/report.xml"
             verbose = true
+        }
+        dockerRegistryConnections {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_342"
+            }
         }
     }
 
@@ -79,9 +94,5 @@ object TestPrimodWin64 : BuildType({
                 """.trimIndent()
             }
         }
-    }
-
-    requirements {
-        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })

--- a/.teamcity/_Self/buildTypes/TestbenchCouplerWin64.kt
+++ b/.teamcity/_Self/buildTypes/TestbenchCouplerWin64.kt
@@ -65,6 +65,13 @@ object TestbenchCouplerWin64 : BuildType({
             name = "Run tests"
             workingDir = "imod_coupler"
             scriptContent = """
+                echo "Configure temporary directories for Docker container"
+                rem Override TEMP and TMP to use container's temp directory
+                rem instead of the host system's temp directory to prevent
+                rem the host system from locking the files
+                set TEMP=C:\Windows\TEMP
+                set TMP=C:\Windows\TEMP
+
                 pixi --version
                 
                 pixi config set --local detached-environments "C:\pixi_envs"

--- a/.teamcity/_Self/buildTypes/TestbenchCouplerWin64.kt
+++ b/.teamcity/_Self/buildTypes/TestbenchCouplerWin64.kt
@@ -8,7 +8,9 @@ import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.PublishMode
 import jetbrains.buildServer.configs.kotlin.buildFeatures.XmlReport
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
 import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 
@@ -60,20 +62,22 @@ object TestbenchCouplerWin64 : BuildType({
 
     steps {
         script {
-            name = "Set up pixi"
-            workingDir = "imod_coupler"
-            scriptContent = """
-                pixi --version
-                pixi install -e dev --frozen
-                pixi list -e dev
-            """.trimIndent()
-        }
-        script {
             name = "Run tests"
             workingDir = "imod_coupler"
             scriptContent = """
+                pixi --version
+                
+                pixi config set --local detached-environments "C:\pixi_envs"
+                pixi install -e dev --frozen
+                pixi list -e dev
+                
                 pixi run -e dev --frozen test-imod-coupler
             """.trimIndent()
+            formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
     }
 
@@ -82,6 +86,11 @@ object TestbenchCouplerWin64 : BuildType({
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod_coupler/report.xml"
             verbose = true
+        }
+        dockerRegistryConnections {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_342"
+            }
         }
     }
 
@@ -111,9 +120,5 @@ object TestbenchCouplerWin64 : BuildType({
                 artifactRules = "+:imod_coupler_release.zip!** => imod_collector_regression"
             }
         }
-    }
-
-    requirements {
-        equals("teamcity.agent.jvm.os.name", "Windows 11")
     }
 })

--- a/.teamcity/_Self/buildTypes/TwineCheck.kt
+++ b/.teamcity/_Self/buildTypes/TwineCheck.kt
@@ -3,7 +3,9 @@ package _Self.buildTypes
 import Templates.GitHubIntegrationTemplate
 import _Self.vcsRoots.ImodCoupler
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 
 object TwineCheck : BuildType({
     name = "Twine"
@@ -21,13 +23,22 @@ object TwineCheck : BuildType({
             id = "Run_twine_check_on_primod"
             workingDir = "imod_coupler"
             scriptContent = """
+                    pixi config set --local detached-environments "C:\pixi_envs"
                     pixi run check-package-primod
                 """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
+            dockerPull = false
         }
     }
 
-    requirements {
-        equals("teamcity.agent.jvm.os.name", "Windows 11")
+    features {
+        dockerRegistryConnections {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_342"
+            }
+        }
     }
 })


### PR DESCRIPTION
In #497 we converted the Lint pipeline step to use docker builds as a test.
Since it was succesful this PR converts the remaining components of the main pipeline to use docker containers as well